### PR TITLE
fix: ship update date fields + scenario fuel speed scaling

### DIFF
--- a/backend/app/calculators/scenario.py
+++ b/backend/app/calculators/scenario.py
@@ -70,17 +70,18 @@ def _modify_voyages(
 ) -> list[dict]:
     modified = copy.deepcopy(voyages)
     speed_factor = 1 + speed_change_pct / 100
-    consumption_factor = speed_factor ** 3
+    # Fuel rate scales as speed³ (cube law) but duration scales as 1/speed,
+    # so total per-voyage fuel scales as speed² — the extra runtime at the
+    # reduced rate partially offsets the rate savings.
+    consumption_factor = speed_factor ** 2
 
     for voyage in modified:
         for leg in voyage.get("legs", []):
-            # Adjust speed
             if leg.get("average_speed_kn"):
                 leg["average_speed_kn"] *= speed_factor
             if leg.get("hours_at_sea") and speed_factor != 0:
                 leg["hours_at_sea"] /= speed_factor
 
-            # Scale consumption (speed³ fuel relationship)
             for rec in leg.get("fuel_records", []):
                 rec["consumption_tonnes"] *= consumption_factor
 

--- a/backend/app/schemas/ship.py
+++ b/backend/app/schemas/ship.py
@@ -96,6 +96,8 @@ class ShipUpdate(BaseModel):
     name: str | None = None
     flag_state: str | None = None
     ship_type: str | None = None
+    build_date: date | None = None
+    delivery_date: date | None = None
     dwt: float | None = None
     gt: float | None = None
     nt: float | None = None


### PR DESCRIPTION
## Summary

- **Closes #1** — `ShipUpdate` Pydantic schema was missing `build_date` and `delivery_date`, so the frontend PUT payload was silently dropped by Pydantic and the backend never persisted edits to those fields.
- **Closes #2** — scenario modeler scaled per-voyage fuel totals by `speed_factor³`, which is the cube law for fuel **rate** but ignores that a slower voyage runs longer. Correct scaling for per-voyage totals is `speed²` (rate × time = speed³ × speed⁻¹ = speed²). At -10% speed on a 500 t leg, fuel is now 405 t (correct) rather than 364.5 t.

## Test plan

- [ ] `cd backend && uv run pytest tests/ -v` — all 28 calculator tests pass
- [ ] `cd backend && uv run ruff check .` — clean
- [ ] Manual: edit a ship's build date in the UI and confirm the PUT response / DB value updates
- [ ] Manual: run a speed-reduction scenario in the frontend and confirm total fuel no longer under-counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)