### PR TITLE
fix: strip timezone from CIICorrection datetimes

### DIFF
--- a/backend/app/schemas/cii_correction.py
+++ b/backend/app/schemas/cii_correction.py
@@ -2,10 +2,20 @@ from datetime import datetime
 from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 
 
 CorrectionType = Literal["ice_class", "electrical_consumer", "cargo_heating"]
+
+
+def _strip_tz(v: datetime | str | None) -> datetime | None:
+    if v is None:
+        return None
+    if isinstance(v, str):
+        v = datetime.fromisoformat(v.replace("Z", "+00:00"))
+    if v.tzinfo is not None:
+        v = v.replace(tzinfo=None)
+    return v
 
 
 class CIICorrectionBase(BaseModel):
@@ -16,6 +26,11 @@ class CIICorrectionBase(BaseModel):
     unit: str | None = None
     co2_offset_tonnes: float = 0.0
     notes: str | None = None
+
+    @field_validator("start_time", "end_time", mode="before")
+    @classmethod
+    def strip_timezone(cls, v: datetime | str | None) -> datetime | None:
+        return _strip_tz(v)
 
 
 class CIICorrectionCreate(CIICorrectionBase):
@@ -30,6 +45,11 @@ class CIICorrectionUpdate(BaseModel):
     unit: str | None = None
     co2_offset_tonnes: float | None = None
     notes: str | None = None
+
+    @field_validator("start_time", "end_time", mode="before")
+    @classmethod
+    def strip_timezone(cls, v: datetime | str | None) -> datetime | None:
+        return _strip_tz(v)
 
 
 class CIICorrectionRead(CIICorrectionBase):


### PR DESCRIPTION
## Summary

POSTing a CII correction with \`start_time\`/\`end_time\` currently 500s on commit:

\`\`\`
asyncpg.exceptions.DataError: invalid input for query argument \$4:
  datetime.datetime(2026, 4, 14, 16, 30, tzinfo=TzInfo(0))
  (can't subtract offset-naive and offset-aware datetimes)
\`\`\`

The \`cii_corrections.start_time\` / \`end_time\` columns are \`TIMESTAMP WITHOUT TIME ZONE\`, but the frontend posts ISO strings with a trailing \`Z\` and Pydantic parses those to tz-aware datetimes. asyncpg refuses to bind a tz-aware value to a naive column.

Fix: add a Pydantic \`field_validator\` on both \`CIICorrectionBase\` and \`CIICorrectionUpdate\` that strips \`tzinfo\`, matching the existing pattern from 3a4b38e (same fix for voyages).

## Test plan

- [ ] \`cd backend && uv run pytest tests/ -v\` — 29 passing
- [ ] \`cd backend && uv run ruff check .\` — clean
- [ ] Manual: add a CII correction with electrical_consumer type, quantity in kWh, and a start/end datetime — should save without 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)