### PR TITLE
fix: speed slider fuel-change display uses speed²

### DIFF
--- a/frontend/src/components/scenarios/SpeedSlider.tsx
+++ b/frontend/src/components/scenarios/SpeedSlider.tsx
@@ -23,7 +23,7 @@ export default function SpeedSlider({ value, onChange }: Props) {
       <div className="text-center text-sm font-medium">
         {value > 0 ? '+' : ''}{value}%
         <span className="text-gray-400 text-xs ml-2">
-          (fuel change: {value > 0 ? '+' : ''}{(((1 + value / 100) ** 3 - 1) * 100).toFixed(1)}%)
+          (fuel change: {value > 0 ? '+' : ''}{(((1 + value / 100) ** 2 - 1) * 100).toFixed(1)}%)
         </span>
       </div>
     </div>


### PR DESCRIPTION
The slider label still showed \`(fuel change: -27.1%)\` at -10% speed because it computed \`(1 + v/100)³ − 1\`. Backend was corrected to speed² in be1b380, so the ETS cost card already shows the right -19% drop — but the slider display was still on the old cube law, making it look like the backend fix hadn't landed.

One-line change: \`** 3\` → \`** 2\` in \`SpeedSlider.tsx:26\`. Now slider and cost card agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)