### PR TITLE
feat: scenario rating-bands chart + multi-year projection

### DIFF
--- a/backend/app/routers/scenarios.py
+++ b/backend/app/routers/scenarios.py
@@ -79,9 +79,38 @@ async def run_what_if(
         "has_fuel_data": has_fuel,
     }
 
+    projection = None
+    if data.projection_years:
+        projection = []
+        for yr in data.projection_years:
+            b = run_scenario(
+                ship.ship_type.value, ship.dwt, ship.gt,
+                voyages_data, yr, fuel_types,
+                speed_change_pct=0.0, fuel_mix=None, eua_price_eur=data.eua_price,
+            )
+            s = run_scenario(
+                ship.ship_type.value, ship.dwt, ship.gt,
+                voyages_data, yr, fuel_types,
+                speed_change_pct=data.speed_change_pct,
+                fuel_mix=data.fuel_mix,
+                eua_price_eur=data.eua_price,
+            )
+            projection.append({
+                "year": yr,
+                "baseline": {
+                    "cii": asdict(b.cii),
+                    "fueleu": asdict(b.fueleu),
+                },
+                "scenario": {
+                    "cii": asdict(s.cii),
+                    "fueleu": asdict(s.fueleu),
+                },
+            })
+
     return {
         "baseline": baseline_dict,
         "scenario": scenario_dict,
         "delta": delta,
         "meta": meta,
+        "projection": projection,
     }

--- a/backend/app/schemas/calculations.py
+++ b/backend/app/schemas/calculations.py
@@ -64,6 +64,7 @@ class ScenarioRequest(BaseModel):
     speed_change_pct: float = 0.0
     fuel_mix: dict[str, float] | None = None
     eua_price: float = 75.0
+    projection_years: list[int] | None = None
 
 
 class ScenarioResponse(BaseModel):

--- a/frontend/src/components/scenarios/CIIBandsChart.tsx
+++ b/frontend/src/components/scenarios/CIIBandsChart.tsx
@@ -1,0 +1,187 @@
+import { formatNumber } from '../../utils/formatters';
+
+interface CIIData {
+  attained_aer: number;
+  rating: string;
+  required_cii: number;
+  band_boundaries: {
+    A_upper: number;
+    B_upper: number;
+    C_upper: number;
+    D_upper: number;
+  };
+}
+
+interface Props {
+  baseline: CIIData;
+  scenario: CIIData;
+  year: number;
+}
+
+const BAND_COLORS = {
+  A: '#bbf7d0', // green-200
+  B: '#d9f99d', // lime-200
+  C: '#fef08a', // yellow-200
+  D: '#fed7aa', // orange-200
+  E: '#fecaca', // red-200
+};
+
+const BAND_TEXT = {
+  A: '#14532d',
+  B: '#365314',
+  C: '#713f12',
+  D: '#7c2d12',
+  E: '#7f1d1d',
+};
+
+export default function CIIBandsChart({ baseline, scenario, year }: Props) {
+  const b = baseline.band_boundaries;
+  // Use the tighter of the two sets of boundaries (bands are year-specific; both results
+  // use the same year so they should match; pick baseline as canonical).
+  const minX = 0;
+  const maxX = Math.max(
+    b.D_upper * 1.3,
+    baseline.attained_aer * 1.1,
+    scenario.attained_aer * 1.1,
+  );
+
+  const W = 1000; // viewBox width
+  const bandsY = 40;
+  const bandsH = 56;
+  const chartPadX = 24;
+  const chartW = W - 2 * chartPadX;
+
+  const scale = (v: number) => chartPadX + ((v - minX) / (maxX - minX)) * chartW;
+
+  const bands: Array<{ key: 'A' | 'B' | 'C' | 'D' | 'E'; from: number; to: number }> = [
+    { key: 'A', from: 0, to: b.A_upper },
+    { key: 'B', from: b.A_upper, to: b.B_upper },
+    { key: 'C', from: b.B_upper, to: b.C_upper },
+    { key: 'D', from: b.C_upper, to: b.D_upper },
+    { key: 'E', from: b.D_upper, to: maxX },
+  ];
+
+  const baseX = scale(baseline.attained_aer);
+  const scenX = scale(scenario.attained_aer);
+  const requiredX = scale(baseline.required_cii);
+
+  const delta = scenario.attained_aer - baseline.attained_aer;
+  const deltaPct = baseline.attained_aer !== 0
+    ? (delta / baseline.attained_aer) * 100 : 0;
+  const improved = delta < 0;
+  const unchanged = Math.abs(deltaPct) < 0.05;
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-4">
+      <div className="flex items-center justify-between mb-2">
+        <h3 className="font-semibold text-sm text-gray-700">
+          CII Rating — Attained AER (gCO₂/t·nm), lower is better · {year}
+        </h3>
+      </div>
+      <svg viewBox={`0 0 ${W} 150`} className="w-full" preserveAspectRatio="xMidYMid meet">
+        {/* Bands */}
+        {bands.map((band) => {
+          const x1 = scale(band.from);
+          const x2 = scale(band.to);
+          const width = x2 - x1;
+          return (
+            <g key={band.key}>
+              <rect
+                x={x1}
+                y={bandsY}
+                width={width}
+                height={bandsH}
+                fill={BAND_COLORS[band.key]}
+              />
+              <text
+                x={x1 + width / 2}
+                y={bandsY + bandsH / 2 + 6}
+                textAnchor="middle"
+                fontSize={18}
+                fontWeight={700}
+                fill={BAND_TEXT[band.key]}
+                opacity={0.7}
+              >
+                {band.key}
+              </text>
+            </g>
+          );
+        })}
+
+        {/* Boundary tick labels below bands */}
+        {[b.A_upper, b.B_upper, b.C_upper, b.D_upper].map((v) => (
+          <g key={v}>
+            <line x1={scale(v)} x2={scale(v)} y1={bandsY} y2={bandsY + bandsH} stroke="#fff" strokeWidth={1.5} />
+            <text
+              x={scale(v)}
+              y={bandsY + bandsH + 14}
+              textAnchor="middle"
+              fontSize={11}
+              fill="#6b7280"
+            >
+              {formatNumber(v)}
+            </text>
+          </g>
+        ))}
+
+        {/* Required CII line */}
+        <line
+          x1={requiredX}
+          x2={requiredX}
+          y1={bandsY - 8}
+          y2={bandsY + bandsH + 8}
+          stroke="#374151"
+          strokeWidth={1}
+          strokeDasharray="3,3"
+        />
+        <text
+          x={requiredX}
+          y={bandsY - 14}
+          textAnchor="middle"
+          fontSize={10}
+          fill="#374151"
+        >
+          required {formatNumber(baseline.required_cii)}
+        </text>
+
+        {/* Connector between baseline and scenario */}
+        {!unchanged && (
+          <line
+            x1={baseX}
+            x2={scenX}
+            y1={bandsY + bandsH / 2}
+            y2={bandsY + bandsH / 2}
+            stroke="#111827"
+            strokeWidth={1}
+            strokeDasharray="2,3"
+            opacity={0.5}
+          />
+        )}
+
+        {/* Baseline marker: filled black dot */}
+        <circle cx={baseX} cy={bandsY + bandsH / 2} r={6} fill="#111827" />
+        {/* Scenario marker: black X */}
+        <g transform={`translate(${scenX}, ${bandsY + bandsH / 2})`}>
+          <line x1={-6} y1={-6} x2={6} y2={6} stroke="#111827" strokeWidth={2.5} strokeLinecap="round" />
+          <line x1={-6} y1={6} x2={6} y2={-6} stroke="#111827" strokeWidth={2.5} strokeLinecap="round" />
+        </g>
+      </svg>
+
+      <div className="flex items-center gap-4 text-xs text-gray-700 mt-2 flex-wrap">
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block w-2 h-2 rounded-full bg-gray-900"></span>
+          Baseline {formatNumber(baseline.attained_aer)} ({baseline.rating})
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="font-bold text-gray-900">✕</span>
+          Scenario {formatNumber(scenario.attained_aer)} ({scenario.rating})
+        </span>
+        {!unchanged && (
+          <span className={`font-medium ${improved ? 'text-green-700' : 'text-red-700'}`}>
+            {improved ? '▼' : '▲'} {formatNumber(Math.abs(delta))} ({improved ? 'improved' : 'worsened'} {Math.abs(deltaPct).toFixed(1)}%)
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/scenarios/CIIProjectionChart.tsx
+++ b/frontend/src/components/scenarios/CIIProjectionChart.tsx
@@ -1,0 +1,177 @@
+import { formatNumber } from '../../utils/formatters';
+
+interface YearEntry {
+  year: number;
+  baseline: {
+    cii: {
+      attained_aer: number;
+      required_cii: number;
+      band_boundaries: { A_upper: number; B_upper: number; C_upper: number; D_upper: number };
+    };
+  };
+  scenario: {
+    cii: {
+      attained_aer: number;
+      required_cii: number;
+      band_boundaries: { A_upper: number; B_upper: number; C_upper: number; D_upper: number };
+    };
+  };
+}
+
+interface Props {
+  projection: YearEntry[];
+}
+
+const BAND_COLORS = {
+  A: '#bbf7d0',
+  B: '#d9f99d',
+  C: '#fef08a',
+  D: '#fed7aa',
+  E: '#fecaca',
+};
+
+export default function CIIProjectionChart({ projection }: Props) {
+  if (!projection || projection.length === 0) return null;
+
+  const years = projection.map((p) => p.year);
+  const minYear = Math.min(...years);
+  const maxYear = Math.max(...years);
+
+  // Y-axis is AER (lower = better, drawn at top)
+  const allValues = projection.flatMap((p) => [
+    p.baseline.cii.attained_aer,
+    p.scenario.cii.attained_aer,
+    p.baseline.cii.band_boundaries.D_upper,
+  ]);
+  const yMax = Math.max(...allValues) * 1.1;
+  const yMin = 0;
+
+  const W = 1000;
+  const H = 280;
+  const padL = 50, padR = 80, padT = 20, padB = 30;
+  const chartW = W - padL - padR;
+  const chartH = H - padT - padB;
+
+  const xScale = (year: number) =>
+    padL + ((year - minYear) / Math.max(1, maxYear - minYear)) * chartW;
+  const yScale = (v: number) =>
+    padT + (1 - (v - yMin) / (yMax - yMin)) * chartH; // inverted so low AER is at top
+
+  // Build polygons (one per band letter) across all years
+  const buildBand = (getLow: (y: YearEntry) => number, getHigh: (y: YearEntry) => number) => {
+    const pts: string[] = [];
+    // top edge left→right using getLow
+    projection.forEach((p) => pts.push(`${xScale(p.year)},${yScale(getLow(p))}`));
+    // bottom edge right→left using getHigh
+    [...projection].reverse().forEach((p) => pts.push(`${xScale(p.year)},${yScale(getHigh(p))}`));
+    return pts.join(' ');
+  };
+
+  // Band regions (from top/best to bottom/worst in AER terms; in pixel terms top=lower AER):
+  // A: 0..A_upper → best → drawn at top
+  const bandA = buildBand(() => yMin, (p) => p.baseline.cii.band_boundaries.A_upper);
+  const bandB = buildBand(
+    (p) => p.baseline.cii.band_boundaries.A_upper,
+    (p) => p.baseline.cii.band_boundaries.B_upper,
+  );
+  const bandC = buildBand(
+    (p) => p.baseline.cii.band_boundaries.B_upper,
+    (p) => p.baseline.cii.band_boundaries.C_upper,
+  );
+  const bandD = buildBand(
+    (p) => p.baseline.cii.band_boundaries.C_upper,
+    (p) => p.baseline.cii.band_boundaries.D_upper,
+  );
+  const bandE = buildBand((p) => p.baseline.cii.band_boundaries.D_upper, () => yMax);
+
+  const baselinePath = projection
+    .map((p, i) => `${i === 0 ? 'M' : 'L'}${xScale(p.year)},${yScale(p.baseline.cii.attained_aer)}`)
+    .join(' ');
+  const scenarioPath = projection
+    .map((p, i) => `${i === 0 ? 'M' : 'L'}${xScale(p.year)},${yScale(p.scenario.cii.attained_aer)}`)
+    .join(' ');
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} className="w-full" preserveAspectRatio="xMidYMid meet">
+      <polygon points={bandA} fill={BAND_COLORS.A} />
+      <polygon points={bandB} fill={BAND_COLORS.B} />
+      <polygon points={bandC} fill={BAND_COLORS.C} />
+      <polygon points={bandD} fill={BAND_COLORS.D} />
+      <polygon points={bandE} fill={BAND_COLORS.E} />
+
+      {/* Rating letters at the right edge */}
+      {(['A', 'B', 'C', 'D', 'E'] as const).map((letter) => {
+        const last = projection[projection.length - 1].baseline.cii.band_boundaries;
+        const yCenter =
+          letter === 'A' ? yScale(last.A_upper / 2)
+            : letter === 'B' ? yScale((last.A_upper + last.B_upper) / 2)
+              : letter === 'C' ? yScale((last.B_upper + last.C_upper) / 2)
+                : letter === 'D' ? yScale((last.C_upper + last.D_upper) / 2)
+                  : yScale(Math.min(yMax, last.D_upper + (yMax - last.D_upper) / 2));
+        return (
+          <text
+            key={letter}
+            x={W - padR + 8}
+            y={yCenter + 4}
+            fontSize={14}
+            fontWeight={700}
+            fill="#374151"
+            opacity={0.6}
+          >
+            {letter}
+          </text>
+        );
+      })}
+
+      {/* Baseline line */}
+      <path d={baselinePath} stroke="#111827" strokeWidth={2} fill="none" />
+      {projection.map((p) => (
+        <circle
+          key={`b-${p.year}`}
+          cx={xScale(p.year)}
+          cy={yScale(p.baseline.cii.attained_aer)}
+          r={3.5}
+          fill="#111827"
+        />
+      ))}
+
+      {/* Scenario line (dashed) */}
+      <path d={scenarioPath} stroke="#111827" strokeWidth={2} fill="none" strokeDasharray="5,4" />
+      {projection.map((p) => (
+        <g key={`s-${p.year}`} transform={`translate(${xScale(p.year)}, ${yScale(p.scenario.cii.attained_aer)})`}>
+          <line x1={-4} y1={-4} x2={4} y2={4} stroke="#111827" strokeWidth={2} strokeLinecap="round" />
+          <line x1={-4} y1={4} x2={4} y2={-4} stroke="#111827" strokeWidth={2} strokeLinecap="round" />
+        </g>
+      ))}
+
+      {/* X-axis year labels */}
+      {projection.map((p) => (
+        <text
+          key={`x-${p.year}`}
+          x={xScale(p.year)}
+          y={H - 8}
+          textAnchor="middle"
+          fontSize={11}
+          fill="#6b7280"
+        >
+          {p.year}
+        </text>
+      ))}
+
+      {/* Y-axis AER ticks */}
+      {[yMin, yMax * 0.25, yMax * 0.5, yMax * 0.75, yMax].map((v) => (
+        <text
+          key={`y-${v}`}
+          x={padL - 6}
+          y={yScale(v) + 4}
+          textAnchor="end"
+          fontSize={10}
+          fill="#6b7280"
+        >
+          {formatNumber(v)}
+        </text>
+      ))}
+      <text x={padL - 6} y={padT - 6} textAnchor="end" fontSize={10} fill="#6b7280">AER</text>
+    </svg>
+  );
+}

--- a/frontend/src/components/scenarios/FuelEUBandsChart.tsx
+++ b/frontend/src/components/scenarios/FuelEUBandsChart.tsx
@@ -1,0 +1,192 @@
+import { formatNumber } from '../../utils/formatters';
+
+interface FuelEUData {
+  weighted_intensity: number;
+  target_intensity: number;
+  compliance_balance_mj: number;
+  compliant: boolean;
+  total_covered_energy_mj: number;
+}
+
+interface Props {
+  baseline: FuelEUData;
+  scenario: FuelEUData;
+  year: number;
+}
+
+// Year → reduction % from 91.16 baseline (FUELEU_TARGETS in backend constants).
+// Duplicated here so the chart can render year markers on the axis without an extra API call.
+const FUELEU_BASELINE = 91.16;
+const FUELEU_REDUCTION_BY_YEAR: Array<{ year: number; pct: number }> = [
+  { year: 2025, pct: 2 },
+  { year: 2030, pct: 6 },
+  { year: 2035, pct: 14.5 },
+  { year: 2040, pct: 31 },
+  { year: 2045, pct: 62 },
+  { year: 2050, pct: 80 },
+];
+const targetFor = (pct: number) => FUELEU_BASELINE * (1 - pct / 100);
+
+export default function FuelEUBandsChart({ baseline, scenario, year }: Props) {
+  // Domain: from 2050 target (most stringent) to slightly above the highest intensity.
+  const topIntensity = Math.max(baseline.weighted_intensity, scenario.weighted_intensity, FUELEU_BASELINE) * 1.02;
+  const minX = targetFor(80) * 0.9;
+  const maxX = topIntensity;
+
+  const W = 1000;
+  const bandsY = 40;
+  const bandsH = 56;
+  const chartPadX = 24;
+  const chartW = W - 2 * chartPadX;
+
+  const scale = (v: number) => chartPadX + ((v - minX) / (maxX - minX)) * chartW;
+
+  // Build bands from strictest target (left / compliant through 2050) to laxest (right).
+  // Each "band" is bounded by two successive year targets.
+  const targetsAsc = [...FUELEU_REDUCTION_BY_YEAR]
+    .sort((a, b) => targetFor(a.pct) - targetFor(b.pct));
+
+  type Band = { from: number; to: number; label: string; color: string };
+  const bands: Band[] = [];
+  // Region to the left of the strictest target → "compliant through 2050+"
+  bands.push({
+    from: minX,
+    to: targetFor(targetsAsc[0].pct),
+    label: `≤${targetsAsc[0].year}`,
+    color: '#bbf7d0',
+  });
+  const colors = ['#d9f99d', '#fef08a', '#fed7aa', '#fca5a5', '#fecaca'];
+  for (let i = 0; i < targetsAsc.length - 1; i++) {
+    bands.push({
+      from: targetFor(targetsAsc[i].pct),
+      to: targetFor(targetsAsc[i + 1].pct),
+      label: `${targetsAsc[i].year}`,
+      color: colors[Math.min(i, colors.length - 1)],
+    });
+  }
+  // Right of the laxest target (2025) → red: non-compliant even today
+  bands.push({
+    from: targetFor(targetsAsc[targetsAsc.length - 1].pct),
+    to: maxX,
+    label: `>${targetsAsc[targetsAsc.length - 1].year}`,
+    color: '#fca5a5',
+  });
+
+  const baseX = scale(baseline.weighted_intensity);
+  const scenX = scale(scenario.weighted_intensity);
+
+  const currentTarget = baseline.target_intensity;
+  const currentTargetX = scale(currentTarget);
+
+  const delta = scenario.weighted_intensity - baseline.weighted_intensity;
+  const deltaPct = baseline.weighted_intensity !== 0
+    ? (delta / baseline.weighted_intensity) * 100 : 0;
+  const improved = delta < 0;
+  const unchanged = Math.abs(deltaPct) < 0.05;
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-4">
+      <div className="flex items-center justify-between mb-2">
+        <h3 className="font-semibold text-sm text-gray-700">
+          FuelEU Intensity (gCO₂eq/MJ), lower is better · {year}
+        </h3>
+      </div>
+      <svg viewBox={`0 0 ${W} 150`} className="w-full" preserveAspectRatio="xMidYMid meet">
+        {bands.map((band, i) => {
+          const x1 = scale(band.from);
+          const x2 = scale(band.to);
+          const w = x2 - x1;
+          if (w <= 0) return null;
+          return (
+            <g key={i}>
+              <rect x={x1} y={bandsY} width={w} height={bandsH} fill={band.color} />
+              {w > 50 && (
+                <text
+                  x={x1 + w / 2}
+                  y={bandsY + bandsH / 2 + 5}
+                  textAnchor="middle"
+                  fontSize={11}
+                  fontWeight={600}
+                  fill="#374151"
+                  opacity={0.7}
+                >
+                  {band.label}
+                </text>
+              )}
+            </g>
+          );
+        })}
+
+        {/* Boundary labels (year targets) below */}
+        {targetsAsc.map((t) => (
+          <g key={t.year}>
+            <line x1={scale(targetFor(t.pct))} x2={scale(targetFor(t.pct))} y1={bandsY} y2={bandsY + bandsH} stroke="#fff" strokeWidth={1.5} />
+            <text
+              x={scale(targetFor(t.pct))}
+              y={bandsY + bandsH + 14}
+              textAnchor="middle"
+              fontSize={10}
+              fill="#6b7280"
+            >
+              {formatNumber(targetFor(t.pct))}
+            </text>
+          </g>
+        ))}
+
+        {/* Current-year target emphasized */}
+        <line
+          x1={currentTargetX}
+          x2={currentTargetX}
+          y1={bandsY - 8}
+          y2={bandsY + bandsH + 8}
+          stroke="#374151"
+          strokeWidth={1}
+          strokeDasharray="3,3"
+        />
+        <text
+          x={currentTargetX}
+          y={bandsY - 14}
+          textAnchor="middle"
+          fontSize={10}
+          fill="#374151"
+        >
+          {year} target {formatNumber(currentTarget)}
+        </text>
+
+        {!unchanged && (
+          <line
+            x1={baseX}
+            x2={scenX}
+            y1={bandsY + bandsH / 2}
+            y2={bandsY + bandsH / 2}
+            stroke="#111827"
+            strokeWidth={1}
+            strokeDasharray="2,3"
+            opacity={0.5}
+          />
+        )}
+        <circle cx={baseX} cy={bandsY + bandsH / 2} r={6} fill="#111827" />
+        <g transform={`translate(${scenX}, ${bandsY + bandsH / 2})`}>
+          <line x1={-6} y1={-6} x2={6} y2={6} stroke="#111827" strokeWidth={2.5} strokeLinecap="round" />
+          <line x1={-6} y1={6} x2={6} y2={-6} stroke="#111827" strokeWidth={2.5} strokeLinecap="round" />
+        </g>
+      </svg>
+
+      <div className="flex items-center gap-4 text-xs text-gray-700 mt-2 flex-wrap">
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block w-2 h-2 rounded-full bg-gray-900"></span>
+          Baseline {formatNumber(baseline.weighted_intensity)} · {baseline.compliant ? 'compliant' : 'deficit'}
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="font-bold text-gray-900">✕</span>
+          Scenario {formatNumber(scenario.weighted_intensity)} · {scenario.compliant ? 'compliant' : 'deficit'}
+        </span>
+        {!unchanged && (
+          <span className={`font-medium ${improved ? 'text-green-700' : 'text-red-700'}`}>
+            {improved ? '▼' : '▲'} {Math.abs(deltaPct).toFixed(2)}% intensity
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/scenarios/FuelEUProjectionChart.tsx
+++ b/frontend/src/components/scenarios/FuelEUProjectionChart.tsx
@@ -1,0 +1,139 @@
+import { formatNumber } from '../../utils/formatters';
+
+interface YearEntry {
+  year: number;
+  baseline: {
+    fueleu: {
+      weighted_intensity: number;
+      target_intensity: number;
+    };
+  };
+  scenario: {
+    fueleu: {
+      weighted_intensity: number;
+      target_intensity: number;
+    };
+  };
+}
+
+interface Props {
+  projection: YearEntry[];
+}
+
+export default function FuelEUProjectionChart({ projection }: Props) {
+  if (!projection || projection.length === 0) return null;
+
+  const years = projection.map((p) => p.year);
+  const minYear = Math.min(...years);
+  const maxYear = Math.max(...years);
+
+  const allValues = projection.flatMap((p) => [
+    p.baseline.fueleu.weighted_intensity,
+    p.scenario.fueleu.weighted_intensity,
+    p.baseline.fueleu.target_intensity,
+    91.16,
+  ]);
+  const yMax = Math.max(...allValues) * 1.05;
+  const yMin = Math.min(...projection.map((p) => p.baseline.fueleu.target_intensity)) * 0.9;
+
+  const W = 1000;
+  const H = 280;
+  const padL = 50, padR = 80, padT = 20, padB = 30;
+  const chartW = W - padL - padR;
+  const chartH = H - padT - padB;
+
+  const xScale = (year: number) =>
+    padL + ((year - minYear) / Math.max(1, maxYear - minYear)) * chartW;
+  const yScale = (v: number) =>
+    padT + (1 - (v - yMin) / (yMax - yMin)) * chartH;
+
+  // Green region: below the target line (compliant)
+  // Red region: above the target line (non-compliant)
+  const targetPts = projection.map((p) => `${xScale(p.year)},${yScale(p.baseline.fueleu.target_intensity)}`);
+  const greenPoly = [
+    `${padL},${yScale(yMin)}`,
+    ...targetPts,
+    `${padL + chartW},${yScale(yMin)}`,
+  ].join(' ');
+  const redPoly = [
+    `${padL},${yScale(yMax)}`,
+    ...targetPts,
+    `${padL + chartW},${yScale(yMax)}`,
+  ].join(' ');
+
+  const baselinePath = projection
+    .map((p, i) => `${i === 0 ? 'M' : 'L'}${xScale(p.year)},${yScale(p.baseline.fueleu.weighted_intensity)}`)
+    .join(' ');
+  const scenarioPath = projection
+    .map((p, i) => `${i === 0 ? 'M' : 'L'}${xScale(p.year)},${yScale(p.scenario.fueleu.weighted_intensity)}`)
+    .join(' ');
+  const targetPath = projection
+    .map((p, i) => `${i === 0 ? 'M' : 'L'}${xScale(p.year)},${yScale(p.baseline.fueleu.target_intensity)}`)
+    .join(' ');
+
+  return (
+    <svg viewBox={`0 0 ${W} ${H}`} className="w-full" preserveAspectRatio="xMidYMid meet">
+      <polygon points={redPoly} fill="#fecaca" opacity={0.6} />
+      <polygon points={greenPoly} fill="#bbf7d0" opacity={0.6} />
+
+      {/* Target line */}
+      <path d={targetPath} stroke="#16a34a" strokeWidth={1.5} fill="none" strokeDasharray="4,3" />
+      <text
+        x={W - padR + 8}
+        y={yScale(projection[projection.length - 1].baseline.fueleu.target_intensity) + 4}
+        fontSize={10}
+        fill="#16a34a"
+      >
+        target
+      </text>
+
+      {/* Baseline */}
+      <path d={baselinePath} stroke="#111827" strokeWidth={2} fill="none" />
+      {projection.map((p) => (
+        <circle
+          key={`b-${p.year}`}
+          cx={xScale(p.year)}
+          cy={yScale(p.baseline.fueleu.weighted_intensity)}
+          r={3.5}
+          fill="#111827"
+        />
+      ))}
+
+      {/* Scenario */}
+      <path d={scenarioPath} stroke="#111827" strokeWidth={2} fill="none" strokeDasharray="5,4" />
+      {projection.map((p) => (
+        <g key={`s-${p.year}`} transform={`translate(${xScale(p.year)}, ${yScale(p.scenario.fueleu.weighted_intensity)})`}>
+          <line x1={-4} y1={-4} x2={4} y2={4} stroke="#111827" strokeWidth={2} strokeLinecap="round" />
+          <line x1={-4} y1={4} x2={4} y2={-4} stroke="#111827" strokeWidth={2} strokeLinecap="round" />
+        </g>
+      ))}
+
+      {projection.map((p) => (
+        <text
+          key={`x-${p.year}`}
+          x={xScale(p.year)}
+          y={H - 8}
+          textAnchor="middle"
+          fontSize={11}
+          fill="#6b7280"
+        >
+          {p.year}
+        </text>
+      ))}
+
+      {[yMin, (yMin + yMax) / 2, yMax].map((v) => (
+        <text
+          key={`y-${v}`}
+          x={padL - 6}
+          y={yScale(v) + 4}
+          textAnchor="end"
+          fontSize={10}
+          fill="#6b7280"
+        >
+          {formatNumber(v)}
+        </text>
+      ))}
+      <text x={padL - 6} y={padT - 6} textAnchor="end" fontSize={10} fill="#6b7280">gCO₂eq/MJ</text>
+    </svg>
+  );
+}

--- a/frontend/src/components/scenarios/ScenarioBandsPanel.tsx
+++ b/frontend/src/components/scenarios/ScenarioBandsPanel.tsx
@@ -1,0 +1,113 @@
+import { useState } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import CIIBandsChart from './CIIBandsChart';
+import FuelEUBandsChart from './FuelEUBandsChart';
+import CIIProjectionChart from './CIIProjectionChart';
+import FuelEUProjectionChart from './FuelEUProjectionChart';
+
+interface CIIData {
+  attained_aer: number;
+  rating: string;
+  required_cii: number;
+  band_boundaries: { A_upper: number; B_upper: number; C_upper: number; D_upper: number };
+}
+
+interface FuelEUData {
+  weighted_intensity: number;
+  target_intensity: number;
+  compliance_balance_mj: number;
+  compliant: boolean;
+  total_covered_energy_mj: number;
+}
+
+interface ProjectionEntry {
+  year: number;
+  baseline: {
+    cii: CIIData;
+    fueleu: FuelEUData;
+  };
+  scenario: {
+    cii: CIIData;
+    fueleu: FuelEUData;
+  };
+}
+
+interface Props {
+  year: number;
+  baselineCii: CIIData;
+  scenarioCii: CIIData;
+  baselineFueleu: FuelEUData;
+  scenarioFueleu: FuelEUData;
+  projection: ProjectionEntry[] | null;
+}
+
+type View = 'cii' | 'fueleu';
+
+export default function ScenarioBandsPanel({
+  year,
+  baselineCii,
+  scenarioCii,
+  baselineFueleu,
+  scenarioFueleu,
+  projection,
+}: Props) {
+  const [view, setView] = useState<View>('cii');
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="space-y-3">
+      {/* Toggle */}
+      <div className="inline-flex rounded-lg border border-gray-200 bg-white p-0.5 text-sm">
+        <button
+          type="button"
+          onClick={() => setView('cii')}
+          className={`px-3 py-1 rounded-md transition-colors ${
+            view === 'cii' ? 'bg-maritime-600 text-white' : 'text-gray-600 hover:text-gray-900'
+          }`}
+        >
+          CII
+        </button>
+        <button
+          type="button"
+          onClick={() => setView('fueleu')}
+          className={`px-3 py-1 rounded-md transition-colors ${
+            view === 'fueleu' ? 'bg-maritime-600 text-white' : 'text-gray-600 hover:text-gray-900'
+          }`}
+        >
+          FuelEU
+        </button>
+      </div>
+
+      {view === 'cii' ? (
+        <CIIBandsChart baseline={baselineCii} scenario={scenarioCii} year={year} />
+      ) : (
+        <FuelEUBandsChart baseline={baselineFueleu} scenario={scenarioFueleu} year={year} />
+      )}
+
+      {projection && projection.length > 1 && (
+        <div className="bg-white rounded-lg border border-gray-200">
+          <button
+            type="button"
+            onClick={() => setExpanded((e) => !e)}
+            className="w-full flex items-center gap-2 px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          >
+            {expanded ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+            Projection {projection[0].year}–{projection[projection.length - 1].year}
+            <span className="text-xs text-gray-400 ml-2">
+              ({view === 'cii' ? 'CII bands tighten ~2%/yr' : 'FuelEU target tightens to -80% by 2050'})
+            </span>
+          </button>
+          {expanded && (
+            <div className="px-4 pb-4">
+              {view === 'cii' ? (
+                <CIIProjectionChart projection={projection} />
+              ) : (
+                <FuelEUProjectionChart projection={projection} />
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/ScenarioModeler.tsx
+++ b/frontend/src/pages/ScenarioModeler.tsx
@@ -6,6 +6,7 @@ import { runScenario } from '../api/calculations';
 import { getShip } from '../api/ships';
 import SpeedSlider from '../components/scenarios/SpeedSlider';
 import FuelMixSlider from '../components/scenarios/FuelMixSlider';
+import ScenarioBandsPanel from '../components/scenarios/ScenarioBandsPanel';
 import MetricCard from '../components/compliance/MetricCard';
 import Breadcrumbs from '../components/shared/Breadcrumbs';
 import { formatNumber, formatCurrency } from '../utils/formatters';
@@ -41,11 +42,15 @@ export default function ScenarioModeler() {
         for (const [k, v] of Object.entries(fuelMix)) {
           if (v > 0) mixNormalized[k] = v / 100;
         }
+        const projectionYears = [year, 2030, 2035, 2040, 2045, 2050]
+          .filter((y, i, arr) => arr.indexOf(y) === i && y >= year)
+          .sort((a, b) => a - b);
         const data = await runScenario(id, {
           year,
           speed_change_pct: speedChange,
           fuel_mix: Object.keys(mixNormalized).length > 0 ? mixNormalized : null,
           eua_price: euaPrice,
+          projection_years: projectionYears,
         });
         setResult(data);
       } catch (err) {
@@ -206,6 +211,29 @@ export default function ScenarioModeler() {
                   <Info className="w-4 h-4 text-blue-500 mt-0.5 shrink-0" />
                   <p className="text-sm text-blue-700">{t('scenario:noEuCoverage')}</p>
                 </div>
+              )}
+
+              {hasVoyages && hasFuel && (
+                <ScenarioBandsPanel
+                  year={year}
+                  baselineCii={baseline.cii as unknown as {
+                    attained_aer: number; rating: string; required_cii: number;
+                    band_boundaries: { A_upper: number; B_upper: number; C_upper: number; D_upper: number };
+                  }}
+                  scenarioCii={scenario.cii as unknown as {
+                    attained_aer: number; rating: string; required_cii: number;
+                    band_boundaries: { A_upper: number; B_upper: number; C_upper: number; D_upper: number };
+                  }}
+                  baselineFueleu={baseline.fueleu as unknown as {
+                    weighted_intensity: number; target_intensity: number;
+                    compliance_balance_mj: number; compliant: boolean; total_covered_energy_mj: number;
+                  }}
+                  scenarioFueleu={scenario.fueleu as unknown as {
+                    weighted_intensity: number; target_intensity: number;
+                    compliance_balance_mj: number; compliant: boolean; total_covered_energy_mj: number;
+                  }}
+                  projection={(result?.projection as Parameters<typeof ScenarioBandsPanel>[0]['projection']) || null}
+                />
               )}
 
               <div className="grid grid-cols-2 gap-4">


### PR DESCRIPTION
## Summary

First-class rating-bands visualization at the top of the scenario modeler. Resolves the \"nothing's moving\" confusion by making bands, required thresholds, and baseline→scenario deltas visible at a glance.

## What's new

**Top of the compare area** (full width, above the baseline/scenario cards):
- Toggle **CII / FuelEU**
- **Current-year bands chart**: A–E (or year-target) colored bands, black dot for baseline, black ✕ for scenario, dashed line for required CII / current-year target, connector + delta summary
- **Foldable** \"Projection 2026–2050\" panel (closed by default) with a time-series view of the bands shifting year-over-year and solid/dashed lines for baseline/scenario AER

## Backend

- \`ScenarioRequest.projection_years: list[int] | None\`
- \`POST /api/ships/{id}/scenario\` runs baseline+scenario for each requested year and returns a \`projection\` array with per-year \`cii\` + \`fueleu\`.

## Files

- \`backend/app/schemas/calculations.py\`, \`backend/app/routers/scenarios.py\`
- \`frontend/src/components/scenarios/CIIBandsChart.tsx\`
- \`frontend/src/components/scenarios/FuelEUBandsChart.tsx\`
- \`frontend/src/components/scenarios/CIIProjectionChart.tsx\`
- \`frontend/src/components/scenarios/FuelEUProjectionChart.tsx\`
- \`frontend/src/components/scenarios/ScenarioBandsPanel.tsx\`
- \`frontend/src/pages/ScenarioModeler.tsx\`

## Test plan

- [ ] \`uv run pytest tests/ -v\` — 29 passing
- [ ] \`uv run ruff check .\` — clean
- [ ] \`npm run check\` — clean, \`npm run build\` — builds
- [ ] Manual: open scenario modeler, confirm CII bands chart shows dot + X, slide speed, confirm X moves
- [ ] Manual: toggle to FuelEU, confirm dot + X on the intensity axis, speed changes don't move X but fuel-mix changes do
- [ ] Manual: expand the projection fold-out, confirm bands shift year-over-year and baseline/scenario lines cross into worse grades as years advance

🤖 Generated with [Claude Code](https://claude.com/claude-code)