### PR TITLE
fix: NumberField helper, stops type=number eating last backspace

### DIFF
--- a/frontend/src/components/shared/NumberField.tsx
+++ b/frontend/src/components/shared/NumberField.tsx
@@ -1,0 +1,92 @@
+import { useState } from 'react';
+
+interface Props {
+  value: number | null;
+  onChange: (value: number | null) => void;
+  onBlur?: () => void;
+  onFocus?: () => void;
+  /** Shown when value is null AND the field is not focused. If omitted, the field shows empty. */
+  fallback?: number;
+  step?: string;
+  min?: string;
+  max?: string;
+  placeholder?: string;
+  className?: string;
+  disabled?: boolean;
+  id?: string;
+  'aria-label'?: string;
+}
+
+/**
+ * Number input without the controlled-react quirks of `type="number"`:
+ * - Backspacing the last digit works (empty → null, not auto-reset to 0).
+ * - Intermediate states like "1." while typing "1.5" aren't silently reparsed.
+ * - Scroll-wheel doesn't change the value.
+ * - `inputMode="decimal"` still surfaces a numeric keypad on mobile.
+ *
+ * Parent stores a `number | null`. While focused, raw keystrokes live in
+ * local text state; on blur, display snaps back to value → fallback → empty.
+ */
+export default function NumberField({
+  value,
+  onChange,
+  onBlur,
+  onFocus,
+  fallback,
+  step,
+  min,
+  max,
+  placeholder,
+  className,
+  disabled,
+  id,
+  'aria-label': ariaLabel,
+}: Props) {
+  const [focused, setFocused] = useState(false);
+  const [text, setText] = useState<string>('');
+
+  const displayValue = focused
+    ? text
+    : value !== null
+      ? String(value)
+      : fallback !== undefined
+        ? String(fallback)
+        : '';
+
+  return (
+    <input
+      id={id}
+      type="text"
+      inputMode="decimal"
+      className={className}
+      step={step}
+      min={min}
+      max={max}
+      placeholder={placeholder}
+      disabled={disabled}
+      aria-label={ariaLabel}
+      value={displayValue}
+      onFocus={() => {
+        setFocused(true);
+        setText(value !== null ? String(value) : '');
+        onFocus?.();
+      }}
+      onBlur={() => {
+        setFocused(false);
+        onBlur?.();
+      }}
+      onChange={(e) => {
+        const v = e.target.value;
+        setText(v);
+        if (v === '' || v === '-' || v === '.') {
+          onChange(null);
+          return;
+        }
+        const parsed = parseFloat(v);
+        if (!Number.isNaN(parsed)) {
+          onChange(parsed);
+        }
+      }}
+    />
+  );
+}

--- a/frontend/src/components/voyage/BerthFuelEntry.tsx
+++ b/frontend/src/components/voyage/BerthFuelEntry.tsx
@@ -1,4 +1,5 @@
 import { Plus, Trash2 } from 'lucide-react';
+import NumberField from '../shared/NumberField';
 
 interface FuelRecord {
   fuel_type_code: string;
@@ -49,11 +50,10 @@ export default function BerthFuelEntry({ portName, records, onChange }: Props) {
             <option value="mdo">MDO</option>
             <option value="electricity">Shore Power</option>
           </select>
-          <input
-            type="number"
-            step="0.1"
+          <NumberField
             value={rec.consumption_tonnes}
-            onChange={(e) => updateRecord(i, 'consumption_tonnes', parseFloat(e.target.value) || 0)}
+            onChange={(v) => updateRecord(i, 'consumption_tonnes', v ?? 0)}
+            step="0.1"
             placeholder="Tonnes"
             className="border border-gray-300 rounded px-2 py-1 text-sm w-24"
           />

--- a/frontend/src/components/voyage/CIICorrectionsEditor.tsx
+++ b/frontend/src/components/voyage/CIICorrectionsEditor.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Plus, Trash2 } from 'lucide-react';
+import NumberField from '../shared/NumberField';
 import {
   listCIICorrections,
   createCIICorrection,
@@ -174,12 +175,11 @@ export default function CIICorrectionsEditor({ voyageId }: Props) {
                   />
                 </td>
                 <td className="py-2 px-2 text-right">
-                  <input
-                    type="number"
-                    step="0.1"
-                    value={it.quantity ?? ''}
-                    onChange={(e) => updateField(it.id, 'quantity', e.target.value === '' ? null : parseFloat(e.target.value))}
+                  <NumberField
+                    value={it.quantity ?? null}
+                    onChange={(v) => updateField(it.id, 'quantity', v)}
                     onBlur={() => commitUpdate(it.id)}
+                    step="0.1"
                     className="border border-gray-200 rounded px-1 py-1 text-xs w-20 text-right"
                   />
                 </td>
@@ -194,12 +194,11 @@ export default function CIICorrectionsEditor({ voyageId }: Props) {
                   />
                 </td>
                 <td className="py-2 px-2 text-right">
-                  <input
-                    type="number"
-                    step="0.01"
+                  <NumberField
                     value={it.co2_offset_tonnes}
-                    onChange={(e) => updateField(it.id, 'co2_offset_tonnes', parseFloat(e.target.value) || 0)}
+                    onChange={(v) => updateField(it.id, 'co2_offset_tonnes', v ?? 0)}
                     onBlur={() => commitUpdate(it.id)}
+                    step="0.01"
                     className="border border-gray-200 rounded px-1 py-1 text-xs w-20 text-right"
                   />
                 </td>
@@ -264,14 +263,10 @@ export default function CIICorrectionsEditor({ voyageId }: Props) {
                   />
                 </td>
                 <td className="py-2 px-2 text-right">
-                  <input
-                    type="number"
+                  <NumberField
+                    value={draft.quantity ?? null}
+                    onChange={(v) => setDraft({ ...draft, quantity: v })}
                     step="0.1"
-                    value={draft.quantity ?? ''}
-                    onChange={(e) => setDraft({
-                      ...draft,
-                      quantity: e.target.value === '' ? null : parseFloat(e.target.value),
-                    })}
                     className="border border-gray-200 rounded px-1 py-1 text-xs w-20 text-right"
                   />
                 </td>
@@ -284,11 +279,10 @@ export default function CIICorrectionsEditor({ voyageId }: Props) {
                   />
                 </td>
                 <td className="py-2 px-2 text-right">
-                  <input
-                    type="number"
-                    step="0.01"
+                  <NumberField
                     value={draft.co2_offset_tonnes}
-                    onChange={(e) => setDraft({ ...draft, co2_offset_tonnes: parseFloat(e.target.value) || 0 })}
+                    onChange={(v) => setDraft({ ...draft, co2_offset_tonnes: v ?? 0 })}
+                    step="0.01"
                     className="border border-gray-200 rounded px-1 py-1 text-xs w-20 text-right"
                   />
                 </td>

--- a/frontend/src/components/voyage/LegFuelEntry.tsx
+++ b/frontend/src/components/voyage/LegFuelEntry.tsx
@@ -1,4 +1,5 @@
 import { Plus, Trash2 } from 'lucide-react';
+import NumberField from '../shared/NumberField';
 
 interface FuelRecord {
   fuel_type_code: string;
@@ -55,11 +56,10 @@ export default function LegFuelEntry({ legIndex, records, onChange }: Props) {
             <option value="e_methanol">E-Methanol</option>
             <option value="green_nh3">Green Ammonia</option>
           </select>
-          <input
-            type="number"
-            step="0.1"
+          <NumberField
             value={rec.consumption_tonnes}
-            onChange={(e) => updateRecord(i, 'consumption_tonnes', parseFloat(e.target.value) || 0)}
+            onChange={(v) => updateRecord(i, 'consumption_tonnes', v ?? 0)}
+            step="0.1"
             placeholder="Tonnes"
             className="border border-gray-300 rounded px-2 py-1 text-sm w-24"
           />

--- a/frontend/src/pages/ScenarioModeler.tsx
+++ b/frontend/src/pages/ScenarioModeler.tsx
@@ -9,6 +9,7 @@ import FuelMixSlider from '../components/scenarios/FuelMixSlider';
 import ScenarioBandsPanel from '../components/scenarios/ScenarioBandsPanel';
 import MetricCard from '../components/compliance/MetricCard';
 import Breadcrumbs from '../components/shared/Breadcrumbs';
+import NumberField from '../components/shared/NumberField';
 import { formatNumber, formatCurrency } from '../utils/formatters';
 
 interface ScenarioMeta {
@@ -225,12 +226,12 @@ export default function ScenarioModeler() {
             </div>
             <div>
               <label className="block text-xs text-gray-500 mb-1">Distance (nm)</label>
-              <input
-                type="number"
+              <NumberField
+                value={overrideDistance}
+                onChange={setOverrideDistance}
+                fallback={meta?.voyage_totals?.distance_nm ?? 0}
                 step="1"
                 min="0"
-                value={overrideDistance ?? meta?.voyage_totals?.distance_nm ?? 0}
-                onChange={(e) => setOverrideDistance(e.target.value === '' ? null : parseFloat(e.target.value))}
                 className="w-full border border-gray-300 rounded-lg px-3 py-1.5 text-sm"
               />
               <p className="text-xs text-gray-400 mt-0.5">
@@ -239,12 +240,12 @@ export default function ScenarioModeler() {
             </div>
             <div>
               <label className="block text-xs text-gray-500 mb-1">Fuel (t)</label>
-              <input
-                type="number"
+              <NumberField
+                value={overrideFuel}
+                onChange={setOverrideFuel}
+                fallback={meta?.voyage_totals?.fuel_tonnes ?? 0}
                 step="0.1"
                 min="0"
-                value={overrideFuel ?? meta?.voyage_totals?.fuel_tonnes ?? 0}
-                onChange={(e) => setOverrideFuel(e.target.value === '' ? null : parseFloat(e.target.value))}
                 className="w-full border border-gray-300 rounded-lg px-3 py-1.5 text-sm"
               />
               <p className="text-xs text-gray-400 mt-0.5">


### PR DESCRIPTION
Users reported you can't backspace the last digit in the scenario totals (and other number fields). Root cause: controlled \`type=\"number\"\` inputs with a numeric fallback (\`value={override ?? fallback ?? 0}\`) reset to the fallback when the field clears, masking the delete. Intermediate states like \"1.\" while typing \"1.5\" also get silently reparsed.

New \`NumberField\` helper:
- Holds the raw string in local state **while focused**
- Commits \`parseFloat(v)\` (or \`null\` for empty) to the parent on every keystroke
- On blur, display snaps back to value → fallback → empty
- Uses \`type=\"text\" inputMode=\"decimal\"\` so mobile keyboards stay numeric while avoiding native-number quirks (scroll-wheel changes, silently dropping \`.\`, etc.)

Swapped into four spots:
- Scenario modeler annual totals (distance, fuel)
- CII corrections editor (quantity, co2_offset_tonnes — edit and draft rows)
- Berth fuel entry (consumption_tonnes)
- Leg fuel entry (consumption_tonnes)

ShipEditor has many number fields with different semantics; leaving those for a follow-up.

## Test plan
- [ ] \`npm run check\`, \`npm run build\` — clean
- [ ] Manual: focus the scenario Fuel (t) input, press backspace repeatedly, confirm you can clear to empty; tab out and confirm it snaps back to the voyage-derived default
- [ ] Manual: edit a CII correction row, backspace out its quantity, confirm it clears and persists null on blur

🤖 Generated with [Claude Code](https://claude.com/claude-code)