### PR TITLE
feat: scenario-only CII corrections (collapsible)

### DIFF
--- a/backend/app/calculators/scenario.py
+++ b/backend/app/calculators/scenario.py
@@ -113,13 +113,17 @@ def run_scenario(
     speed_change_pct: float = 0.0,
     fuel_mix: dict[str, float] | None = None,
     eua_price_eur: float = 75.0,
+    corrections: list[dict] | None = None,
 ) -> ScenarioResult:
     modified_voyages = _modify_voyages(baseline_voyages, speed_change_pct, fuel_mix, fuel_types)
 
     fuel_records = _flatten_fuel_records(modified_voyages)
     distance = _total_distance(modified_voyages)
 
-    cii = calculate_cii(ship_type, dwt, gt, fuel_records, distance, year, fuel_types)
+    cii = calculate_cii(
+        ship_type, dwt, gt, fuel_records, distance, year, fuel_types,
+        corrections=corrections,
+    )
     fueleu = calculate_fueleu(modified_voyages, year, fuel_types)
     ets = calculate_eu_ets(modified_voyages, year, fuel_types, eua_price_eur)
 

--- a/backend/app/routers/scenarios.py
+++ b/backend/app/routers/scenarios.py
@@ -94,6 +94,7 @@ async def run_what_if(
         speed_change_pct=data.speed_change_pct,
         fuel_mix=data.fuel_mix,
         eua_price_eur=data.eua_price,
+        corrections=data.extra_corrections,
     )
 
     baseline_dict = {
@@ -159,6 +160,7 @@ async def run_what_if(
                 speed_change_pct=data.speed_change_pct,
                 fuel_mix=data.fuel_mix,
                 eua_price_eur=data.eua_price,
+                corrections=data.extra_corrections,
             )
             projection.append({
                 "year": yr,

--- a/backend/app/schemas/calculations.py
+++ b/backend/app/schemas/calculations.py
@@ -70,6 +70,10 @@ class ScenarioRequest(BaseModel):
     # voyage log is incomplete and the user wants to enter yearly totals.
     override_distance_nm: float | None = None
     override_fuel_tonnes: float | None = None
+    # Ephemeral CII corrections applied only to the scenario branch (not
+    # persisted, not applied to baseline) — used for "what if I also record
+    # these corrections" planning.
+    extra_corrections: list[dict] | None = None
 
 
 class ScenarioResponse(BaseModel):

--- a/frontend/src/components/scenarios/ScenarioCorrectionsEditor.tsx
+++ b/frontend/src/components/scenarios/ScenarioCorrectionsEditor.tsx
@@ -1,0 +1,144 @@
+import { useTranslation } from 'react-i18next';
+import { Plus, Trash2 } from 'lucide-react';
+import NumberField from '../shared/NumberField';
+import type { CorrectionType, CIICorrectionInput } from '../../types/ciiCorrection';
+import { CORRECTION_UNIT_SUGGESTIONS } from '../../types/ciiCorrection';
+
+interface Props {
+  corrections: CIICorrectionInput[];
+  onChange: (next: CIICorrectionInput[]) => void;
+}
+
+const TYPES: CorrectionType[] = ['ice_class', 'electrical_consumer', 'cargo_heating'];
+
+function emptyRow(): CIICorrectionInput {
+  return {
+    correction_type: 'ice_class',
+    start_time: null,
+    end_time: null,
+    quantity: null,
+    unit: CORRECTION_UNIT_SUGGESTIONS.ice_class,
+    co2_offset_tonnes: 0,
+    notes: '',
+  };
+}
+
+export default function ScenarioCorrectionsEditor({ corrections, onChange }: Props) {
+  const { t } = useTranslation('compliance');
+
+  const add = () => onChange([...corrections, emptyRow()]);
+  const update = (i: number, patch: Partial<CIICorrectionInput>) => {
+    const next = corrections.slice();
+    next[i] = { ...next[i], ...patch };
+    onChange(next);
+  };
+  const remove = (i: number) => onChange(corrections.filter((_, idx) => idx !== i));
+
+  const typeLabel = (type: CorrectionType) => {
+    if (type === 'ice_class') return t('corrections.typeIceClass');
+    if (type === 'electrical_consumer') return t('corrections.typeElectricalConsumer');
+    return t('corrections.typeCargoHeating');
+  };
+
+  return (
+    <div>
+      <p className="text-xs text-gray-500 mb-3">
+        Scenario-only CII corrections — not saved to the voyage. Each correction subtracts its CO₂ offset from the scenario's attained CII.
+      </p>
+
+      {corrections.length === 0 && (
+        <p className="text-sm text-gray-400 italic mb-3">No extra corrections applied.</p>
+      )}
+
+      {corrections.length > 0 && (
+        <table className="w-full text-sm mb-3">
+          <thead>
+            <tr className="border-b text-xs text-gray-500">
+              <th className="text-left py-2 px-2">{t('corrections.type')}</th>
+              <th className="text-right py-2 px-2">{t('corrections.quantity')}</th>
+              <th className="text-left py-2 px-2">{t('corrections.unit')}</th>
+              <th className="text-right py-2 px-2">{t('corrections.co2Offset')}</th>
+              <th className="text-left py-2 px-2">{t('corrections.notes')}</th>
+              <th className="py-2 px-2"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {corrections.map((c, i) => (
+              <tr key={i} className="border-b border-gray-50">
+                <td className="py-2 px-2">
+                  <select
+                    value={c.correction_type}
+                    onChange={(e) => {
+                      const v = e.target.value as CorrectionType;
+                      update(i, {
+                        correction_type: v,
+                        unit: c.unit === CORRECTION_UNIT_SUGGESTIONS[c.correction_type]
+                          ? CORRECTION_UNIT_SUGGESTIONS[v]
+                          : c.unit,
+                      });
+                    }}
+                    className="border border-gray-200 rounded px-1 py-1 text-xs w-full"
+                  >
+                    {TYPES.map((ty) => (
+                      <option key={ty} value={ty}>{typeLabel(ty)}</option>
+                    ))}
+                  </select>
+                </td>
+                <td className="py-2 px-2 text-right">
+                  <NumberField
+                    value={c.quantity ?? null}
+                    onChange={(v) => update(i, { quantity: v })}
+                    step="0.1"
+                    className="border border-gray-200 rounded px-1 py-1 text-xs w-20 text-right"
+                  />
+                </td>
+                <td className="py-2 px-2">
+                  <input
+                    type="text"
+                    value={c.unit ?? ''}
+                    onChange={(e) => update(i, { unit: e.target.value || null })}
+                    placeholder={CORRECTION_UNIT_SUGGESTIONS[c.correction_type]}
+                    className="border border-gray-200 rounded px-1 py-1 text-xs w-16"
+                  />
+                </td>
+                <td className="py-2 px-2 text-right">
+                  <NumberField
+                    value={c.co2_offset_tonnes}
+                    onChange={(v) => update(i, { co2_offset_tonnes: v ?? 0 })}
+                    step="0.01"
+                    className="border border-gray-200 rounded px-1 py-1 text-xs w-20 text-right"
+                  />
+                </td>
+                <td className="py-2 px-2">
+                  <input
+                    type="text"
+                    value={c.notes ?? ''}
+                    onChange={(e) => update(i, { notes: e.target.value || null })}
+                    className="border border-gray-200 rounded px-1 py-1 text-xs w-full"
+                  />
+                </td>
+                <td className="py-2 px-2 text-right">
+                  <button
+                    type="button"
+                    onClick={() => remove(i)}
+                    className="text-gray-400 hover:text-red-500"
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      <button
+        type="button"
+        onClick={add}
+        className="text-sm text-maritime-600 hover:underline flex items-center gap-1"
+      >
+        <Plus className="w-4 h-4" /> {t('corrections.add')}
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/pages/ScenarioModeler.tsx
+++ b/frontend/src/pages/ScenarioModeler.tsx
@@ -1,15 +1,17 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { AlertTriangle, Info, Loader2, RotateCcw } from 'lucide-react';
+import { AlertTriangle, ChevronDown, ChevronRight, Info, Loader2, RotateCcw } from 'lucide-react';
 import { runScenario } from '../api/calculations';
 import { getShip } from '../api/ships';
 import SpeedSlider from '../components/scenarios/SpeedSlider';
 import FuelMixSlider from '../components/scenarios/FuelMixSlider';
 import ScenarioBandsPanel from '../components/scenarios/ScenarioBandsPanel';
+import ScenarioCorrectionsEditor from '../components/scenarios/ScenarioCorrectionsEditor';
 import MetricCard from '../components/compliance/MetricCard';
 import Breadcrumbs from '../components/shared/Breadcrumbs';
 import NumberField from '../components/shared/NumberField';
+import type { CIICorrectionInput } from '../types/ciiCorrection';
 import { formatNumber, formatCurrency } from '../utils/formatters';
 
 interface ScenarioMeta {
@@ -45,6 +47,9 @@ export default function ScenarioModeler() {
   // Annual totals overrides. `null` means use voyage-derived values.
   const [overrideDistance, setOverrideDistance] = useState<number | null>(null);
   const [overrideFuel, setOverrideFuel] = useState<number | null>(null);
+  // Scenario-only CII corrections (not persisted).
+  const [extraCorrections, setExtraCorrections] = useState<CIICorrectionInput[]>([]);
+  const [correctionsOpen, setCorrectionsOpen] = useState(false);
 
   useEffect(() => {
     if (id) getShip(id).then((s) => setShipName(s.name));
@@ -70,6 +75,12 @@ export default function ScenarioModeler() {
           projection_years: projectionYears,
           override_distance_nm: overrideDistance,
           override_fuel_tonnes: overrideFuel,
+          extra_corrections: extraCorrections.length > 0
+            ? extraCorrections.map((c) => ({
+                correction_type: c.correction_type,
+                co2_offset_tonnes: c.co2_offset_tonnes,
+              }))
+            : null,
         });
         setResult(data);
       } catch (err) {
@@ -79,7 +90,7 @@ export default function ScenarioModeler() {
       }
     }, 300);
     return () => clearTimeout(timer);
-  }, [id, year, speedChange, fuelMix, euaPrice, overrideDistance, overrideFuel]);
+  }, [id, year, speedChange, fuelMix, euaPrice, overrideDistance, overrideFuel, extraCorrections]);
 
   const baseline = result?.baseline as Record<string, Record<string, unknown>> | undefined;
   const scenario = result?.scenario as Record<string, Record<string, unknown>> | undefined;
@@ -320,6 +331,32 @@ export default function ScenarioModeler() {
                   <p className="text-sm text-blue-700">{t('scenario:noEuCoverage')}</p>
                 </div>
               )}
+
+              {/* Scenario-only CII corrections — collapsible, local-only */}
+              <div className="bg-white rounded-lg border border-gray-200">
+                <button
+                  type="button"
+                  onClick={() => setCorrectionsOpen((o) => !o)}
+                  className="w-full flex items-center gap-2 px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50"
+                >
+                  {correctionsOpen ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+                  {t('compliance:corrections.title')}
+                  {extraCorrections.length > 0 && (
+                    <span className="text-xs bg-maritime-100 text-maritime-700 rounded-full px-2 py-0.5">
+                      {extraCorrections.length}
+                    </span>
+                  )}
+                  <span className="text-xs text-gray-400 ml-2">scenario-only</span>
+                </button>
+                {correctionsOpen && (
+                  <div className="px-4 pb-4">
+                    <ScenarioCorrectionsEditor
+                      corrections={extraCorrections}
+                      onChange={setExtraCorrections}
+                    />
+                  </div>
+                )}
+              </div>
 
               {(baseAer > 0 || scenAer > 0) && (
                 <ScenarioBandsPanel


### PR DESCRIPTION
Adds a collapsible **CII Corrections** panel to the scenario builder. Rows are local-only — not persisted to the voyage — and applied only to the scenario branch so the delta reflects *\"what if I recorded these corrections\"*.

## Changes

**Backend**
- \`ScenarioRequest.extra_corrections: list[dict] | None\`
- \`run_scenario\` now accepts a \`corrections\` param and forwards it to \`calculate_cii\`
- The scenario branch (both the current-year calc and each projection year) includes \`extra_corrections\`; baseline does not

**Frontend**
- New \`ScenarioCorrectionsEditor\` component — local-only rows with type dropdown, quantity, unit, CO₂ offset (t), notes, delete (uses the fixed \`NumberField\`)
- Inserted as a collapsible panel in \`ScenarioModeler\` matching the projection's ChevronDown/ChevronRight style, with a count badge in the header and a \"scenario-only\" hint

## Test plan
- [ ] Backend: \`uv run pytest tests/\` — 29 passing, \`uv run ruff check .\` — clean
- [ ] Frontend: \`npm run check\`, \`npm run build\` — clean
- [ ] Manual: expand the panel, add a correction with 100 t CO₂ offset, confirm the scenario CII bands marker moves but baseline stays put
- [ ] Manual: add an ice_class correction, confirm the multi-year projection's scenario line also reflects the offset

🤖 Generated with [Claude Code](https://claude.com/claude-code)