### PR TITLE
feat: auto-populate CII correction CO₂ offset from rule of thumb

### DIFF
--- a/frontend/src/components/scenarios/ScenarioCorrectionsEditor.tsx
+++ b/frontend/src/components/scenarios/ScenarioCorrectionsEditor.tsx
@@ -3,6 +3,12 @@ import { Plus, Trash2 } from 'lucide-react';
 import NumberField from '../shared/NumberField';
 import type { CorrectionType, CIICorrectionInput } from '../../types/ciiCorrection';
 import { CORRECTION_UNIT_SUGGESTIONS } from '../../types/ciiCorrection';
+import {
+  RULES_OF_THUMB,
+  ruleOfThumbOffset,
+  isOverridden,
+  nextOffsetOnQuantityChange,
+} from '../../utils/ciiCorrectionRules';
 
 interface Props {
   corrections: CIICorrectionInput[];
@@ -87,7 +93,12 @@ export default function ScenarioCorrectionsEditor({ corrections, onChange }: Pro
                 <td className="py-2 px-2 text-right">
                   <NumberField
                     value={c.quantity ?? null}
-                    onChange={(v) => update(i, { quantity: v })}
+                    onChange={(v) => update(i, {
+                      quantity: v,
+                      co2_offset_tonnes: nextOffsetOnQuantityChange(
+                        c.correction_type, c.quantity, c.co2_offset_tonnes, v,
+                      ),
+                    })}
                     step="0.1"
                     className="border border-gray-200 rounded px-1 py-1 text-xs w-20 text-right"
                   />
@@ -108,6 +119,28 @@ export default function ScenarioCorrectionsEditor({ corrections, onChange }: Pro
                     step="0.01"
                     className="border border-gray-200 rounded px-1 py-1 text-xs w-20 text-right"
                   />
+                  {(() => {
+                    const rule = RULES_OF_THUMB[c.correction_type];
+                    const expected = ruleOfThumbOffset(c.correction_type, c.quantity);
+                    if (!rule || expected == null) return null;
+                    if (!isOverridden(c.correction_type, c.quantity, c.co2_offset_tonnes)) {
+                      return (
+                        <div className="text-[10px] text-gray-400 mt-0.5" title={rule.note}>
+                          auto ({rule.note})
+                        </div>
+                      );
+                    }
+                    const delta = c.co2_offset_tonnes - expected;
+                    const sign = delta >= 0 ? '+' : '−';
+                    return (
+                      <div
+                        className={`text-[10px] mt-0.5 ${delta >= 0 ? 'text-amber-600' : 'text-blue-600'}`}
+                        title={`Rule of thumb: ${expected.toFixed(2)} t (${rule.note})`}
+                      >
+                        {sign}{Math.abs(delta).toFixed(2)} t vs rule
+                      </div>
+                    );
+                  })()}
                 </td>
                 <td className="py-2 px-2">
                   <input

--- a/frontend/src/components/voyage/CIICorrectionsEditor.tsx
+++ b/frontend/src/components/voyage/CIICorrectionsEditor.tsx
@@ -14,6 +14,12 @@ import type {
   CorrectionType,
 } from '../../types/ciiCorrection';
 import { CORRECTION_UNIT_SUGGESTIONS } from '../../types/ciiCorrection';
+import {
+  RULES_OF_THUMB,
+  ruleOfThumbOffset,
+  isOverridden,
+  nextOffsetOnQuantityChange,
+} from '../../utils/ciiCorrectionRules';
 
 interface Props {
   voyageId: string;
@@ -177,7 +183,14 @@ export default function CIICorrectionsEditor({ voyageId }: Props) {
                 <td className="py-2 px-2 text-right">
                   <NumberField
                     value={it.quantity ?? null}
-                    onChange={(v) => updateField(it.id, 'quantity', v)}
+                    onChange={(v) => {
+                      const nextOffset = nextOffsetOnQuantityChange(
+                        it.correction_type, it.quantity, it.co2_offset_tonnes, v,
+                      );
+                      setItems(items.map((x) => x.id === it.id
+                        ? { ...x, quantity: v, co2_offset_tonnes: nextOffset }
+                        : x));
+                    }}
                     onBlur={() => commitUpdate(it.id)}
                     step="0.1"
                     className="border border-gray-200 rounded px-1 py-1 text-xs w-20 text-right"
@@ -201,6 +214,28 @@ export default function CIICorrectionsEditor({ voyageId }: Props) {
                     step="0.01"
                     className="border border-gray-200 rounded px-1 py-1 text-xs w-20 text-right"
                   />
+                  {(() => {
+                    const rule = RULES_OF_THUMB[it.correction_type];
+                    const expected = ruleOfThumbOffset(it.correction_type, it.quantity);
+                    if (!rule || expected == null) return null;
+                    if (!isOverridden(it.correction_type, it.quantity, it.co2_offset_tonnes)) {
+                      return (
+                        <div className="text-[10px] text-gray-400 mt-0.5" title={rule.note}>
+                          auto ({rule.note})
+                        </div>
+                      );
+                    }
+                    const delta = it.co2_offset_tonnes - expected;
+                    const sign = delta >= 0 ? '+' : '−';
+                    return (
+                      <div
+                        className={`text-[10px] mt-0.5 ${delta >= 0 ? 'text-amber-600' : 'text-blue-600'}`}
+                        title={`Rule of thumb: ${expected.toFixed(2)} t (${rule.note})`}
+                      >
+                        {sign}{Math.abs(delta).toFixed(2)} t vs rule
+                      </div>
+                    );
+                  })()}
                 </td>
                 <td className="py-2 px-2">
                   <input
@@ -265,7 +300,13 @@ export default function CIICorrectionsEditor({ voyageId }: Props) {
                 <td className="py-2 px-2 text-right">
                   <NumberField
                     value={draft.quantity ?? null}
-                    onChange={(v) => setDraft({ ...draft, quantity: v })}
+                    onChange={(v) => setDraft({
+                      ...draft,
+                      quantity: v,
+                      co2_offset_tonnes: nextOffsetOnQuantityChange(
+                        draft.correction_type, draft.quantity, draft.co2_offset_tonnes, v,
+                      ),
+                    })}
                     step="0.1"
                     className="border border-gray-200 rounded px-1 py-1 text-xs w-20 text-right"
                   />
@@ -285,6 +326,28 @@ export default function CIICorrectionsEditor({ voyageId }: Props) {
                     step="0.01"
                     className="border border-gray-200 rounded px-1 py-1 text-xs w-20 text-right"
                   />
+                  {(() => {
+                    const rule = RULES_OF_THUMB[draft.correction_type];
+                    const expected = ruleOfThumbOffset(draft.correction_type, draft.quantity);
+                    if (!rule || expected == null) return null;
+                    if (!isOverridden(draft.correction_type, draft.quantity, draft.co2_offset_tonnes)) {
+                      return (
+                        <div className="text-[10px] text-gray-400 mt-0.5" title={rule.note}>
+                          auto ({rule.note})
+                        </div>
+                      );
+                    }
+                    const delta = draft.co2_offset_tonnes - expected;
+                    const sign = delta >= 0 ? '+' : '−';
+                    return (
+                      <div
+                        className={`text-[10px] mt-0.5 ${delta >= 0 ? 'text-amber-600' : 'text-blue-600'}`}
+                        title={`Rule of thumb: ${expected.toFixed(2)} t (${rule.note})`}
+                      >
+                        {sign}{Math.abs(delta).toFixed(2)} t vs rule
+                      </div>
+                    );
+                  })()}
                 </td>
                 <td className="py-2 px-2">
                   <input

--- a/frontend/src/utils/ciiCorrectionRules.ts
+++ b/frontend/src/utils/ciiCorrectionRules.ts
@@ -1,0 +1,75 @@
+import type { CorrectionType } from '../types/ciiCorrection';
+
+/**
+ * Rough rules of thumb mapping a correction's raw `quantity` → CO₂ offset (t).
+ * These are defaults to help users fill the field — they can always override.
+ *
+ * Electrical consumers (reefer / aux loads):
+ *   kWh × aux SFOC (≈210 g/kWh for MGO) × CF (≈3.2 t CO₂ / t fuel) / 10⁶
+ *   ≈ 0.00067 t CO₂ per kWh
+ *
+ * Cargo heating (tanker boilers burning MGO/VLSFO for heating):
+ *   t fuel × CF (≈3.15, blend of VLSFO 3.114 and MGO 3.206)
+ *   ≈ 3.15 t CO₂ per t fuel
+ *
+ * Ice-class correction is too ship-size dependent for a universal rule;
+ * we leave it to the user.
+ */
+export interface Rule {
+  factor: number;
+  unit: string;
+  note: string;
+}
+
+export const RULES_OF_THUMB: Record<CorrectionType, Rule | null> = {
+  electrical_consumer: {
+    factor: 0.00067,
+    unit: 'kWh',
+    note: 'aux engine 210 g/kWh × CF 3.2',
+  },
+  cargo_heating: {
+    factor: 3.15,
+    unit: 'tonnes',
+    note: 'boiler fuel CF ≈ 3.15',
+  },
+  ice_class: null,
+};
+
+const EPSILON = 0.001;
+
+export function ruleOfThumbOffset(
+  correctionType: CorrectionType,
+  quantity: number | null | undefined,
+): number | null {
+  if (quantity == null) return null;
+  const rule = RULES_OF_THUMB[correctionType];
+  if (!rule) return null;
+  return quantity * rule.factor;
+}
+
+export function isOverridden(
+  correctionType: CorrectionType,
+  quantity: number | null | undefined,
+  co2OffsetTonnes: number,
+): boolean {
+  const expected = ruleOfThumbOffset(correctionType, quantity);
+  if (expected == null) return false;
+  return Math.abs(co2OffsetTonnes - expected) > EPSILON;
+}
+
+/**
+ * Given the previous row and a new quantity, return the offset the row
+ * should carry: if the row's current offset matched the old rule, follow
+ * the new rule; otherwise leave the manual override alone.
+ */
+export function nextOffsetOnQuantityChange(
+  correctionType: CorrectionType,
+  previousQuantity: number | null | undefined,
+  currentOffset: number,
+  newQuantity: number | null | undefined,
+): number {
+  const wasOverridden = isOverridden(correctionType, previousQuantity, currentOffset);
+  if (wasOverridden) return currentOffset;
+  const expected = ruleOfThumbOffset(correctionType, newQuantity);
+  return expected ?? currentOffset;
+}


### PR DESCRIPTION
Quantity field now drives the CO₂ offset field via a rule of thumb. If the user manually overrides the offset, we keep the override and display a `+/−X.XX t vs rule` hint so it's obvious they've diverged.

## Rules
- `electrical_consumer` — kWh × **0.00067** (aux engine 210 g/kWh × CF 3.2)
- `cargo_heating` — tonnes × **3.15** (boiler fuel CF ≈ 3.15)
- `ice_class` — no rule (ship-size dependent), offset stays manual

## Implementation note
"Overridden" is derived by comparing current offset to the rule's expected value with a 1e-3 epsilon, so there's no extra per-row state. Applied to both the scenario-only editor and the voyage-persisted editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF