### PR TITLE
fix: units on CII bands summary, 1-decimal percentages

### DIFF
--- a/frontend/src/components/scenarios/CIIBandsChart.tsx
+++ b/frontend/src/components/scenarios/CIIBandsChart.tsx
@@ -170,15 +170,15 @@ export default function CIIBandsChart({ baseline, scenario, year }: Props) {
       <div className="flex items-center gap-4 text-xs text-gray-700 mt-2 flex-wrap">
         <span className="flex items-center gap-1.5">
           <span className="inline-block w-2 h-2 rounded-full bg-gray-900"></span>
-          Baseline {formatNumber(baseline.attained_aer, 3)} ({baseline.rating})
+          Baseline {formatNumber(baseline.attained_aer, 3)} gCO₂/t·nm ({baseline.rating})
         </span>
         <span className="flex items-center gap-1.5">
           <span className="font-bold text-gray-900">✕</span>
-          Scenario {formatNumber(scenario.attained_aer, 3)} ({scenario.rating})
+          Scenario {formatNumber(scenario.attained_aer, 3)} gCO₂/t·nm ({scenario.rating})
         </span>
         {!unchanged && (
           <span className={`font-medium ${improved ? 'text-green-700' : 'text-red-700'}`}>
-            {improved ? '▼' : '▲'} {formatNumber(Math.abs(delta), 3)} ({improved ? 'improved' : 'worsened'} {Math.abs(deltaPct).toFixed(3)}%)
+            {improved ? '▼' : '▲'} {formatNumber(Math.abs(delta), 3)} gCO₂/t·nm ({improved ? 'improved' : 'worsened'} {Math.abs(deltaPct).toFixed(1)}%)
           </span>
         )}
       </div>

--- a/frontend/src/components/scenarios/FuelEUBandsChart.tsx
+++ b/frontend/src/components/scenarios/FuelEUBandsChart.tsx
@@ -175,15 +175,15 @@ export default function FuelEUBandsChart({ baseline, scenario, year }: Props) {
       <div className="flex items-center gap-4 text-xs text-gray-700 mt-2 flex-wrap">
         <span className="flex items-center gap-1.5">
           <span className="inline-block w-2 h-2 rounded-full bg-gray-900"></span>
-          Baseline {formatNumber(baseline.weighted_intensity, 3)} · {baseline.compliant ? 'compliant' : 'deficit'}
+          Baseline {formatNumber(baseline.weighted_intensity, 3)} gCO₂eq/MJ · {baseline.compliant ? 'compliant' : 'deficit'}
         </span>
         <span className="flex items-center gap-1.5">
           <span className="font-bold text-gray-900">✕</span>
-          Scenario {formatNumber(scenario.weighted_intensity, 3)} · {scenario.compliant ? 'compliant' : 'deficit'}
+          Scenario {formatNumber(scenario.weighted_intensity, 3)} gCO₂eq/MJ · {scenario.compliant ? 'compliant' : 'deficit'}
         </span>
         {!unchanged && (
           <span className={`font-medium ${improved ? 'text-green-700' : 'text-red-700'}`}>
-            {improved ? '▼' : '▲'} {Math.abs(deltaPct).toFixed(3)}% intensity
+            {improved ? '▼' : '▲'} {Math.abs(deltaPct).toFixed(1)}% intensity
           </span>
         )}
       </div>

--- a/frontend/src/components/scenarios/SpeedSlider.tsx
+++ b/frontend/src/components/scenarios/SpeedSlider.tsx
@@ -23,7 +23,7 @@ export default function SpeedSlider({ value, onChange }: Props) {
       <div className="text-center text-sm font-medium">
         {value > 0 ? '+' : ''}{value}%
         <span className="text-gray-400 text-xs ml-2">
-          (fuel change: {value > 0 ? '+' : ''}{(((1 + value / 100) ** 2 - 1) * 100).toFixed(3)}%)
+          (fuel change: {value > 0 ? '+' : ''}{(((1 + value / 100) ** 2 - 1) * 100).toFixed(1)}%)
         </span>
       </div>
     </div>

--- a/frontend/src/pages/ScenarioModeler.tsx
+++ b/frontend/src/pages/ScenarioModeler.tsx
@@ -141,7 +141,7 @@ export default function ScenarioModeler() {
   const ciiTrend = ciiDiff !== 0 ? ciiGradeTrend : aerTrend;
   const ciiTrendValue = ciiDiff !== 0
     ? `${Math.abs(ciiDiff)} grade${Math.abs(ciiDiff) > 1 ? 's' : ''}`
-    : Math.abs(aerPct) >= 0.001 ? `${Math.abs(aerPct).toFixed(3)}%` : undefined;
+    : Math.abs(aerPct) >= 0.05 ? `${Math.abs(aerPct).toFixed(1)}%` : undefined;
 
   const baseFueleu = (baseline?.fueleu?.weighted_intensity as number) || 0;
   const scenFueleu = (scenario?.fueleu?.weighted_intensity as number) || 0;
@@ -161,10 +161,10 @@ export default function ScenarioModeler() {
       : fueleuBalanceImproved ? 'down' : 'up';
   // Prefer intensity delta when it exists (fuel mix changed); otherwise fall back to balance
   const fueleuTrend = Math.abs(fueleuPct) >= 0.01 ? fueleuIntensityTrend : fueleuBalanceTrend;
-  const fueleuTrendValue = Math.abs(fueleuPct) >= 0.001
-    ? `${Math.abs(fueleuPct).toFixed(3)}%`
-    : Math.abs(fueleuBalancePct) >= 0.001
-      ? `balance ${fueleuBalancePct > 0 ? '+' : ''}${fueleuBalancePct.toFixed(3)}%`
+  const fueleuTrendValue = Math.abs(fueleuPct) >= 0.05
+    ? `${Math.abs(fueleuPct).toFixed(1)}%`
+    : Math.abs(fueleuBalancePct) >= 0.05
+      ? `balance ${fueleuBalancePct > 0 ? '+' : ''}${fueleuBalancePct.toFixed(1)}%`
       : undefined;
 
   const formatBalance = (mj: number) => {
@@ -424,7 +424,7 @@ export default function ScenarioModeler() {
                       value={etsValue(scenario)}
                       valueColor={hasMeaningfulEu ? colorFor(etsTrend) : undefined}
                       trend={hasMeaningfulEu && Math.abs(etsPct) >= 0.01 ? etsTrend : undefined}
-                      trendValue={hasMeaningfulEu && Math.abs(etsPct) >= 0.001 ? `${Math.abs(etsPct).toFixed(3)}%` : undefined}
+                      trendValue={hasMeaningfulEu && Math.abs(etsPct) >= 0.05 ? `${Math.abs(etsPct).toFixed(1)}%` : undefined}
                     />
                   </div>
                 </div>


### PR DESCRIPTION
- CII bands summary now reads `Baseline 6.772 gCO₂/t·nm (E)` / `Scenario 5.762 gCO₂/t·nm (E)` / `▼ 1.009 gCO₂/t·nm (improved 14.9%)`
- FuelEU bands summary carries `gCO₂eq/MJ` on the summary rows
- Percentages across the scenario page → 1 decimal (CII/FuelEU delta %, MetricCard trend badges, SpeedSlider fuel-change)
- Threshold bumped 0.001% → 0.05% so a shown trend is never "0.0%"
- Absolute compliance values stay at 3 decimals