### PR TITLE
feat(responsiveness 1/6): scenario builder layout on small screens

### DIFF
--- a/frontend/src/components/scenarios/ScenarioCorrectionsEditor.tsx
+++ b/frontend/src/components/scenarios/ScenarioCorrectionsEditor.tsx
@@ -57,7 +57,8 @@ export default function ScenarioCorrectionsEditor({ corrections, onChange }: Pro
       )}
 
       {corrections.length > 0 && (
-        <table className="w-full text-sm mb-3">
+        <div className="overflow-x-auto -mx-1 px-1 mb-3">
+        <table className="w-full min-w-[640px] text-sm">
           <thead>
             <tr className="border-b text-xs text-gray-500">
               <th className="text-left py-2 px-2">{t('corrections.type')}</th>
@@ -163,6 +164,7 @@ export default function ScenarioCorrectionsEditor({ corrections, onChange }: Pro
             ))}
           </tbody>
         </table>
+        </div>
       )}
 
       <button

--- a/frontend/src/components/voyage/CIICorrectionsEditor.tsx
+++ b/frontend/src/components/voyage/CIICorrectionsEditor.tsx
@@ -131,7 +131,8 @@ export default function CIICorrectionsEditor({ voyageId }: Props) {
       )}
 
       {(items.length > 0 || draft) && (
-        <table className="w-full text-sm">
+        <div className="overflow-x-auto -mx-1 px-1">
+        <table className="w-full min-w-[760px] text-sm">
           <thead>
             <tr className="border-b text-xs text-gray-500">
               <th className="text-left py-2 px-2">{t('corrections.type')}</th>
@@ -377,6 +378,7 @@ export default function CIICorrectionsEditor({ voyageId }: Props) {
             )}
           </tbody>
         </table>
+        </div>
       )}
     </div>
   );

--- a/frontend/src/pages/ScenarioModeler.tsx
+++ b/frontend/src/pages/ScenarioModeler.tsx
@@ -209,8 +209,8 @@ export default function ScenarioModeler() {
         </div>
       )}
 
-      <div className="grid grid-cols-3 gap-6">
-        <div className="col-span-1 space-y-6">
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="lg:col-span-1 space-y-6">
           <div className="bg-white rounded-lg border border-gray-200 p-4">
             <label className="block text-sm font-medium text-gray-700 mb-2">{t('scenario:year')}</label>
             <select value={year} onChange={(e) => setYear(Number(e.target.value))} className="w-full border border-gray-300 rounded-lg px-3 py-2">
@@ -295,7 +295,7 @@ export default function ScenarioModeler() {
           </div>
         </div>
 
-        <div className="col-span-2 relative">
+        <div className="lg:col-span-2 relative">
           {loading && baseline && scenario && (
             <div className="absolute top-2 right-2 z-10 flex items-center gap-2 text-xs text-gray-500 bg-white/80 rounded-full px-2 py-1 border border-gray-200">
               <Loader2 className="w-3 h-3 animate-spin" /> updating
@@ -381,7 +381,7 @@ export default function ScenarioModeler() {
                 )}
               </div>
 
-              <div className="grid grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
                   <h3 className="font-semibold text-gray-500 text-sm mb-3">{t('scenario:baseline')}</h3>
                   <div className="space-y-3">


### PR DESCRIPTION
Chunk 1 of a six-chunk responsiveness pass. Audit findings and plan shared in chat.

## Changes
- Scenario outer grid: `grid-cols-3` → `grid-cols-1 lg:grid-cols-3` — sidebar stacks above the compare area below ~1024px
- Baseline/scenario cards: `grid-cols-2` → `grid-cols-1 md:grid-cols-2` — stacks on phones
- Scenario `ScenarioCorrectionsEditor` table: wrapped in `overflow-x-auto` + `min-w-[640px]` so seven columns stay readable and scroll on narrow screens
- Voyage-persisted `CIICorrectionsEditor` table: same treatment with 760px min-width (nine columns)

## Next up
2. SVG chart text — stop labels becoming ~3px at narrow widths
3. App shell mobile drawer
4. Code splitting (290kB → per-route chunks)
5. Projection-year sampling during slider drag
6. Touch polish

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF