### PR TITLE
feat(responsiveness 2/6): CSS-pixel font-size in scenario SVG charts

### DIFF
--- a/frontend/src/components/scenarios/CIIBandsChart.tsx
+++ b/frontend/src/components/scenarios/CIIBandsChart.tsx
@@ -97,7 +97,7 @@ export default function CIIBandsChart({ baseline, scenario, year }: Props) {
                 x={x1 + width / 2}
                 y={bandsY + bandsH / 2 + 6}
                 textAnchor="middle"
-                fontSize={18}
+                style={{ fontSize: '18px' }}
                 fontWeight={700}
                 fill={BAND_TEXT[band.key]}
                 opacity={0.7}
@@ -116,7 +116,7 @@ export default function CIIBandsChart({ baseline, scenario, year }: Props) {
               x={scale(v)}
               y={bandsY + bandsH + 14}
               textAnchor="middle"
-              fontSize={11}
+              style={{ fontSize: '12px' }}
               fill="#6b7280"
             >
               {formatNumber(v, 3)}
@@ -138,7 +138,7 @@ export default function CIIBandsChart({ baseline, scenario, year }: Props) {
           x={requiredX}
           y={bandsY - 14}
           textAnchor="middle"
-          fontSize={10}
+          style={{ fontSize: '11px' }}
           fill="#374151"
         >
           required {formatNumber(baseline.required_cii, 3)}

--- a/frontend/src/components/scenarios/CIIProjectionChart.tsx
+++ b/frontend/src/components/scenarios/CIIProjectionChart.tsx
@@ -113,7 +113,7 @@ export default function CIIProjectionChart({ projection }: Props) {
             key={letter}
             x={W - padR + 8}
             y={yCenter + 4}
-            fontSize={14}
+            style={{ fontSize: '14px' }}
             fontWeight={700}
             fill="#374151"
             opacity={0.6}
@@ -151,7 +151,7 @@ export default function CIIProjectionChart({ projection }: Props) {
           x={xScale(p.year)}
           y={H - 8}
           textAnchor="middle"
-          fontSize={11}
+          style={{ fontSize: '12px' }}
           fill="#6b7280"
         >
           {p.year}
@@ -165,13 +165,13 @@ export default function CIIProjectionChart({ projection }: Props) {
           x={padL - 6}
           y={yScale(v) + 4}
           textAnchor="end"
-          fontSize={10}
+          style={{ fontSize: '11px' }}
           fill="#6b7280"
         >
           {formatNumber(v, 3)}
         </text>
       ))}
-      <text x={padL - 6} y={padT - 6} textAnchor="end" fontSize={10} fill="#6b7280">AER</text>
+      <text x={padL - 6} y={padT - 6} textAnchor="end" style={{ fontSize: '11px' }} fill="#6b7280">AER</text>
     </svg>
   );
 }

--- a/frontend/src/components/scenarios/FuelEUBandsChart.tsx
+++ b/frontend/src/components/scenarios/FuelEUBandsChart.tsx
@@ -105,7 +105,7 @@ export default function FuelEUBandsChart({ baseline, scenario, year }: Props) {
                   x={x1 + w / 2}
                   y={bandsY + bandsH / 2 + 5}
                   textAnchor="middle"
-                  fontSize={11}
+                  style={{ fontSize: '12px' }}
                   fontWeight={600}
                   fill="#374151"
                   opacity={0.7}
@@ -125,7 +125,7 @@ export default function FuelEUBandsChart({ baseline, scenario, year }: Props) {
               x={scale(targetFor(t.pct))}
               y={bandsY + bandsH + 14}
               textAnchor="middle"
-              fontSize={10}
+              style={{ fontSize: '11px' }}
               fill="#6b7280"
             >
               {formatNumber(targetFor(t.pct), 3)}
@@ -147,7 +147,7 @@ export default function FuelEUBandsChart({ baseline, scenario, year }: Props) {
           x={currentTargetX}
           y={bandsY - 14}
           textAnchor="middle"
-          fontSize={10}
+          style={{ fontSize: '11px' }}
           fill="#374151"
         >
           {year} target {formatNumber(currentTarget, 3)}

--- a/frontend/src/components/scenarios/FuelEUProjectionChart.tsx
+++ b/frontend/src/components/scenarios/FuelEUProjectionChart.tsx
@@ -81,7 +81,7 @@ export default function FuelEUProjectionChart({ projection }: Props) {
       <text
         x={W - padR + 8}
         y={yScale(projection[projection.length - 1].baseline.fueleu.target_intensity) + 4}
-        fontSize={10}
+        style={{ fontSize: '11px' }}
         fill="#16a34a"
       >
         target
@@ -114,7 +114,7 @@ export default function FuelEUProjectionChart({ projection }: Props) {
           x={xScale(p.year)}
           y={H - 8}
           textAnchor="middle"
-          fontSize={11}
+          style={{ fontSize: '12px' }}
           fill="#6b7280"
         >
           {p.year}
@@ -127,13 +127,13 @@ export default function FuelEUProjectionChart({ projection }: Props) {
           x={padL - 6}
           y={yScale(v) + 4}
           textAnchor="end"
-          fontSize={10}
+          style={{ fontSize: '11px' }}
           fill="#6b7280"
         >
           {formatNumber(v, 3)}
         </text>
       ))}
-      <text x={padL - 6} y={padT - 6} textAnchor="end" fontSize={10} fill="#6b7280">gCO₂eq/MJ</text>
+      <text x={padL - 6} y={padT - 6} textAnchor="end" style={{ fontSize: '11px' }} fill="#6b7280">gCO₂eq/MJ</text>
     </svg>
   );
 }


### PR DESCRIPTION
Chunk 2 of 6. SVG `<text fontSize={N}>` measures in viewBox units and shrinks with the container — on a 300px phone that made chart labels ~3.3 CSS px. Swapped to `style={{fontSize: 'Npx'}}` so CSS owns the size and labels stay legible at any viewport. Bumped small sizes (10→11, 11→12) for touch comfort; 14 and 18 unchanged.