### PR TITLE
feat(responsiveness 3/6): mobile drawer for sidebar

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Sidebar from './components/layout/Sidebar';
 import TopBar from './components/layout/TopBar';
@@ -11,29 +12,45 @@ import ScenarioModeler from './pages/ScenarioModeler';
 import ProjectionView from './pages/ProjectionView';
 import LoginRegister from './pages/LoginRegister';
 
+function Shell() {
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  return (
+    <div className="flex h-screen overflow-hidden">
+      {/* Backdrop — only visible on mobile when drawer is open */}
+      {drawerOpen && (
+        <div
+          onClick={() => setDrawerOpen(false)}
+          className="md:hidden fixed inset-0 bg-black/40 z-30"
+          aria-hidden="true"
+        />
+      )}
+      <Sidebar open={drawerOpen} onClose={() => setDrawerOpen(false)} />
+      <div className="flex-1 flex flex-col overflow-hidden">
+        <TopBar onHamburger={() => setDrawerOpen((o) => !o)} />
+        <main className="flex-1 overflow-auto p-4 md:p-6">
+          <Routes>
+            <Route path="/" element={<FleetDashboard />} />
+            <Route path="/ships/new" element={<ShipEditor />} />
+            <Route path="/ships/:id" element={<ShipDetail />} />
+            <Route path="/ships/:id/edit" element={<ShipEditor />} />
+            <Route path="/ships/:id/voyages/new" element={<VoyageCreator />} />
+            <Route path="/voyages/:id" element={<VoyageDetail />} />
+            <Route path="/ships/:id/report" element={<AnnualReport />} />
+            <Route path="/ships/:id/scenario" element={<ScenarioModeler />} />
+            <Route path="/ships/:id/projection" element={<ProjectionView />} />
+            <Route path="/login" element={<LoginRegister />} />
+          </Routes>
+        </main>
+      </div>
+    </div>
+  );
+}
+
 export default function App() {
   return (
     <BrowserRouter>
-      <div className="flex h-screen overflow-hidden">
-        <Sidebar />
-        <div className="flex-1 flex flex-col overflow-hidden">
-          <TopBar />
-          <main className="flex-1 overflow-auto p-6">
-            <Routes>
-              <Route path="/" element={<FleetDashboard />} />
-              <Route path="/ships/new" element={<ShipEditor />} />
-              <Route path="/ships/:id" element={<ShipDetail />} />
-              <Route path="/ships/:id/edit" element={<ShipEditor />} />
-              <Route path="/ships/:id/voyages/new" element={<VoyageCreator />} />
-              <Route path="/voyages/:id" element={<VoyageDetail />} />
-              <Route path="/ships/:id/report" element={<AnnualReport />} />
-              <Route path="/ships/:id/scenario" element={<ScenarioModeler />} />
-              <Route path="/ships/:id/projection" element={<ProjectionView />} />
-              <Route path="/login" element={<LoginRegister />} />
-            </Routes>
-          </main>
-        </div>
-      </div>
+      <Shell />
     </BrowserRouter>
   );
 }

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,8 +1,13 @@
 import { Link, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { Ship, LogIn } from 'lucide-react';
+import { Ship, LogIn, X } from 'lucide-react';
 
-export default function Sidebar() {
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+export default function Sidebar({ open, onClose }: Props) {
   const location = useLocation();
   const { t } = useTranslation('common');
 
@@ -11,13 +16,32 @@ export default function Sidebar() {
     { path: '/login', label: t('nav.login'), icon: LogIn },
   ];
 
+  // On mobile (below md): fixed-position drawer that slides in from the left.
+  // On md+: static in the flex row, always visible.
+  const mobileClass = open ? 'translate-x-0' : '-translate-x-full';
+
   return (
-    <aside className="w-64 bg-maritime-900 text-white flex flex-col">
-      <div className="p-4 border-b border-maritime-700">
+    <aside
+      className={`
+        fixed md:static inset-y-0 left-0 z-40
+        w-64 bg-maritime-900 text-white flex flex-col
+        transform transition-transform duration-200 ease-out
+        ${mobileClass} md:translate-x-0
+      `}
+    >
+      <div className="p-4 border-b border-maritime-700 flex items-center justify-between">
         <h1 className="text-xl font-bold flex items-center gap-2">
           <Ship className="w-6 h-6" />
           {t('appTitle')}
         </h1>
+        <button
+          type="button"
+          onClick={onClose}
+          className="md:hidden text-maritime-200 hover:text-white p-1 -mr-1"
+          aria-label="Close menu"
+        >
+          <X className="w-5 h-5" />
+        </button>
       </div>
       <nav className="flex-1 p-2">
         {navItems.map((item) => {
@@ -27,6 +51,7 @@ export default function Sidebar() {
             <Link
               key={item.path}
               to={item.path}
+              onClick={onClose}
               className={`flex items-center gap-3 px-3 py-2 rounded-lg mb-1 transition-colors ${
                 active
                   ? 'bg-maritime-700 text-white'

--- a/frontend/src/components/layout/TopBar.tsx
+++ b/frontend/src/components/layout/TopBar.tsx
@@ -1,32 +1,46 @@
 import { useTranslation } from 'react-i18next';
 import { useAuthStore } from '../../stores/authStore';
-import { LogOut, User } from 'lucide-react';
+import { LogOut, Menu, User } from 'lucide-react';
 import LanguageSwitcher from './LanguageSwitcher';
 
-export default function TopBar() {
+interface Props {
+  onHamburger: () => void;
+}
+
+export default function TopBar({ onHamburger }: Props) {
   const { t } = useTranslation('common');
   const { user, logout } = useAuthStore();
 
   return (
-    <header className="h-14 bg-white border-b border-gray-200 flex items-center justify-between px-6">
-      <LanguageSwitcher />
-      <div className="flex items-center gap-4">
+    <header className="h-14 bg-white border-b border-gray-200 flex items-center justify-between px-4 md:px-6 gap-3">
+      <div className="flex items-center gap-3 min-w-0">
+        <button
+          type="button"
+          onClick={onHamburger}
+          className="md:hidden p-1 -ml-1 text-gray-600 hover:text-gray-900"
+          aria-label="Open menu"
+        >
+          <Menu className="w-5 h-5" />
+        </button>
+        <LanguageSwitcher />
+      </div>
+      <div className="flex items-center gap-2 md:gap-4 min-w-0">
         {user ? (
           <>
-            <span className="text-sm text-gray-600 flex items-center gap-1">
-              <User className="w-4 h-4" />
-              {user.email}
+            <span className="text-sm text-gray-600 flex items-center gap-1 min-w-0">
+              <User className="w-4 h-4 shrink-0" />
+              <span className="truncate max-w-[140px] md:max-w-xs">{user.email}</span>
             </span>
             <button
               onClick={logout}
-              className="text-sm text-gray-500 hover:text-gray-700 flex items-center gap-1"
+              className="text-sm text-gray-500 hover:text-gray-700 flex items-center gap-1 shrink-0"
             >
               <LogOut className="w-4 h-4" />
-              {t('auth.logout')}
+              <span className="hidden sm:inline">{t('auth.logout')}</span>
             </button>
           </>
         ) : (
-          <span className="text-sm text-gray-400">{t('auth.anonymousMode')}</span>
+          <span className="text-sm text-gray-400 truncate">{t('auth.anonymousMode')}</span>
         )}
       </div>
     </header>


### PR DESCRIPTION
Chunk 3 of 6. Sidebar collapses to a slide-in drawer below md (768px).

- Hamburger in TopBar (mobile only) toggles the drawer
- Fixed-positioned drawer slides in from the left with 200ms transition
- Backdrop overlay taps to close
- Nav-link click auto-closes
- Sidebar gains an X button in its header on mobile
- Main padding drops p-6 → p-4 on mobile
- TopBar email truncates, logout label hides on xs