### PR TITLE
feat(responsiveness 4/6): route-level code splitting

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,16 +1,28 @@
-import { useState } from 'react';
+import { lazy, Suspense, useState } from 'react';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { Loader2 } from 'lucide-react';
 import Sidebar from './components/layout/Sidebar';
 import TopBar from './components/layout/TopBar';
 import FleetDashboard from './pages/FleetDashboard';
 import ShipDetail from './pages/ShipDetail';
-import ShipEditor from './pages/ShipEditor';
-import VoyageCreator from './pages/VoyageCreator';
-import VoyageDetail from './pages/VoyageDetail';
-import AnnualReport from './pages/AnnualReport';
-import ScenarioModeler from './pages/ScenarioModeler';
-import ProjectionView from './pages/ProjectionView';
 import LoginRegister from './pages/LoginRegister';
+
+// Heavy routes are code-split — map tiles, charts, form-heavy pages don't
+// need to ship in the initial bundle.
+const ShipEditor = lazy(() => import('./pages/ShipEditor'));
+const VoyageCreator = lazy(() => import('./pages/VoyageCreator'));
+const VoyageDetail = lazy(() => import('./pages/VoyageDetail'));
+const AnnualReport = lazy(() => import('./pages/AnnualReport'));
+const ScenarioModeler = lazy(() => import('./pages/ScenarioModeler'));
+const ProjectionView = lazy(() => import('./pages/ProjectionView'));
+
+function RouteFallback() {
+  return (
+    <div className="flex items-center justify-center gap-2 py-16 text-gray-400 text-sm">
+      <Loader2 className="w-4 h-4 animate-spin" /> loading…
+    </div>
+  );
+}
 
 function Shell() {
   const [drawerOpen, setDrawerOpen] = useState(false);
@@ -29,18 +41,20 @@ function Shell() {
       <div className="flex-1 flex flex-col overflow-hidden">
         <TopBar onHamburger={() => setDrawerOpen((o) => !o)} />
         <main className="flex-1 overflow-auto p-4 md:p-6">
-          <Routes>
-            <Route path="/" element={<FleetDashboard />} />
-            <Route path="/ships/new" element={<ShipEditor />} />
-            <Route path="/ships/:id" element={<ShipDetail />} />
-            <Route path="/ships/:id/edit" element={<ShipEditor />} />
-            <Route path="/ships/:id/voyages/new" element={<VoyageCreator />} />
-            <Route path="/voyages/:id" element={<VoyageDetail />} />
-            <Route path="/ships/:id/report" element={<AnnualReport />} />
-            <Route path="/ships/:id/scenario" element={<ScenarioModeler />} />
-            <Route path="/ships/:id/projection" element={<ProjectionView />} />
-            <Route path="/login" element={<LoginRegister />} />
-          </Routes>
+          <Suspense fallback={<RouteFallback />}>
+            <Routes>
+              <Route path="/" element={<FleetDashboard />} />
+              <Route path="/ships/new" element={<ShipEditor />} />
+              <Route path="/ships/:id" element={<ShipDetail />} />
+              <Route path="/ships/:id/edit" element={<ShipEditor />} />
+              <Route path="/ships/:id/voyages/new" element={<VoyageCreator />} />
+              <Route path="/voyages/:id" element={<VoyageDetail />} />
+              <Route path="/ships/:id/report" element={<AnnualReport />} />
+              <Route path="/ships/:id/scenario" element={<ScenarioModeler />} />
+              <Route path="/ships/:id/projection" element={<ProjectionView />} />
+              <Route path="/login" element={<LoginRegister />} />
+            </Routes>
+          </Suspense>
         </main>
       </div>
     </div>


### PR DESCRIPTION
Chunk 4 of 6. Heavy routes now load on demand via `React.lazy`.

Initial JS: **947 kB (gzip 290 kB) → 385 kB (gzip 126 kB)** — about 56% smaller first paint.

Eager: FleetDashboard, ShipDetail, LoginRegister (the common entry paths).
Lazy: ShipEditor, VoyageCreator (leaflet), VoyageDetail, AnnualReport, ScenarioModeler, ProjectionView (recharts).

Resulting chunks:
- `index` 385 kB — react, router, i18n, stores, fleet + ship-detail
- `ProjectionView` 351 kB — lazily hauls in recharts
- `VoyageCreator` 164 kB — lazily hauls in leaflet
- `ScenarioModeler` 29 kB — pure SVG, already svelte
- Others <12 kB each

A tiny spinner Suspense fallback covers the lazy-chunk fetch.