### PR TITLE
feat(responsiveness 6/6): touch-friendlier scenario sliders

### DIFF
--- a/frontend/src/components/scenarios/FuelMixSlider.tsx
+++ b/frontend/src/components/scenarios/FuelMixSlider.tsx
@@ -17,17 +17,17 @@ export default function FuelMixSlider({ fuelMix, onChange, availableFuels }: Pro
     <div className="space-y-3">
       <h4 className="text-sm font-medium text-gray-700">Fuel Mix (%)</h4>
       {availableFuels.map((fuel) => (
-        <div key={fuel.code} className="flex items-center gap-3">
-          <label className="w-32 text-sm text-gray-600 truncate">{fuel.name}</label>
+        <div key={fuel.code} className="flex items-center gap-2 md:gap-3">
+          <label className="w-20 md:w-32 text-xs md:text-sm text-gray-600 truncate">{fuel.name}</label>
           <input
             type="range"
             min={0}
             max={100}
             value={fuelMix[fuel.code] || 0}
             onChange={(e) => handleChange(fuel.code, Number(e.target.value))}
-            className="flex-1"
+            className="flex-1 min-w-0 h-6 md:h-4"
           />
-          <span className="w-12 text-right text-sm font-mono">
+          <span className="w-10 md:w-12 text-right text-xs md:text-sm font-mono">
             {(fuelMix[fuel.code] || 0).toFixed(0)}%
           </span>
         </div>

--- a/frontend/src/components/scenarios/SpeedSlider.tsx
+++ b/frontend/src/components/scenarios/SpeedSlider.tsx
@@ -7,8 +7,8 @@ export default function SpeedSlider({ value, onChange }: Props) {
   return (
     <div className="space-y-2">
       <h4 className="text-sm font-medium text-gray-700">Speed Adjustment</h4>
-      <div className="flex items-center gap-3">
-        <span className="text-xs text-gray-500 w-10">-20%</span>
+      <div className="flex items-center gap-2 md:gap-3">
+        <span className="text-xs text-gray-500 w-10 shrink-0">-20%</span>
         <input
           type="range"
           min={-20}
@@ -16,13 +16,13 @@ export default function SpeedSlider({ value, onChange }: Props) {
           step={1}
           value={value}
           onChange={(e) => onChange(Number(e.target.value))}
-          className="flex-1"
+          className="flex-1 min-w-0 h-6 md:h-4"
         />
-        <span className="text-xs text-gray-500 w-10">+10%</span>
+        <span className="text-xs text-gray-500 w-10 shrink-0 text-right">+10%</span>
       </div>
-      <div className="text-center text-sm font-medium">
-        {value > 0 ? '+' : ''}{value}%
-        <span className="text-gray-400 text-xs ml-2">
+      <div className="text-center text-sm font-medium flex flex-wrap items-center justify-center gap-x-2">
+        <span>{value > 0 ? '+' : ''}{value}%</span>
+        <span className="text-gray-400 text-xs">
           (fuel change: {value > 0 ? '+' : ''}{(((1 + value / 100) ** 2 - 1) * 100).toFixed(1)}%)
         </span>
       </div>


### PR DESCRIPTION
Chunk 6 of 6 — final of the responsiveness pass.

FuelMixSlider + SpeedSlider tighten label widths on mobile (w-32 → w-20, w-12 → w-10), reduce row gaps (gap-3 → gap-2), widen the slider track on touch (h-4 → h-6), and gain `min-w-0` on the flex-1 so the track actually shrinks instead of overflowing. SpeedSlider's value + fuel-change readout wraps onto two lines on narrow screens.